### PR TITLE
Maintain squeue & cqueue manually in io-uring.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ targets = ["x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]
 async-task = "4"
 bytes = { version = "1", optional = true }
 cfg-if = "1"
+crossbeam-queue = "0.3"
 futures-util = "0.3"
 once_cell = "1"
 slab = "0.4"
@@ -31,7 +32,6 @@ tempfile = "3"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-crossbeam-queue = "0.3"
 widestring = "1"
 windows-sys = { version = "0.48", features = [
     "Win32_Foundation",

--- a/examples/tick.rs
+++ b/examples/tick.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 fn main() {
     compio::task::block_on(async {
-        let mut interval = interval(Duration::from_secs(1));
+        let mut interval = interval(Duration::from_secs(2));
         let mut ctrlc = ctrl_c();
         loop {
             let ctrlc = std::pin::pin!(&mut ctrlc);

--- a/src/driver/iour/mod.rs
+++ b/src/driver/iour/mod.rs
@@ -1,11 +1,13 @@
 use crate::driver::{Entry, Poller};
+use crossbeam_queue::SegQueue;
 use io_uring::{
+    cqueue,
     opcode::MsgRingData,
     squeue,
     types::{Fd, SubmitArgs, Timespec},
     IoUring,
 };
-use std::{cell::UnsafeCell, io, marker::PhantomData, mem::MaybeUninit, time::Duration};
+use std::{io, mem::MaybeUninit, time::Duration};
 
 pub use libc::{sockaddr_storage, socklen_t};
 pub use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -23,8 +25,8 @@ pub trait OpCode {
 /// Low-level driver of io-uring.
 pub struct Driver {
     inner: IoUring,
-    // Using inner mut.
-    _p: PhantomData<UnsafeCell<()>>,
+    squeue: SegQueue<squeue::Entry>,
+    cqueue: SegQueue<Entry>,
 }
 
 impl Driver {
@@ -37,23 +39,58 @@ impl Driver {
     pub fn with_entries(entries: u32) -> io::Result<Self> {
         Ok(Self {
             inner: IoUring::new(entries)?,
-            _p: PhantomData,
+            squeue: SegQueue::default(),
+            cqueue: SegQueue::default(),
         })
     }
 
-    unsafe fn push_entry(&self, entry: io_uring::squeue::Entry) -> io::Result<()> {
-        if self.inner.submission_shared().is_full() {
-            self.inner.submit()?;
+    unsafe fn submit(&self, timeout: Option<Duration>) -> io::Result<()> {
+        let mut inner_squeue = self.inner.submission_shared();
+        while !self.squeue.is_empty() || !inner_squeue.is_empty() {
+            while !inner_squeue.is_full() {
+                if let Some(entry) = self.squeue.pop() {
+                    inner_squeue.push(&entry).unwrap();
+                } else {
+                    break;
+                }
+            }
+            inner_squeue.sync();
+
+            let res = if self.squeue.is_empty() {
+                // Last part of submission queue, wait till timeout.
+                if let Some(duration) = timeout {
+                    let timespec = timespec(duration);
+                    let args = SubmitArgs::new().timespec(&timespec);
+                    self.inner.submitter().submit_with_args(1, &args)
+                } else {
+                    self.inner.submit_and_wait(1)
+                }
+            } else {
+                self.inner.submit()
+            };
+            match res {
+                Ok(_) => Ok(()),
+                Err(e) => match e.raw_os_error() {
+                    Some(libc::ETIME) | Some(libc::EINTR) => {
+                        Err(io::Error::new(io::ErrorKind::TimedOut, e))
+                    }
+                    Some(libc::EBUSY) => Ok(()),
+                    _ => Err(e),
+                },
+            }?;
+            inner_squeue.sync();
+
+            for entry in self.inner.completion_shared() {
+                self.cqueue.push(create_entry(entry));
+            }
         }
-        self.inner.submission_shared().push(&entry).unwrap();
         Ok(())
     }
 
-    unsafe fn poll_entries(&self, entries: &mut [MaybeUninit<Entry>]) -> usize {
-        let cqe = unsafe { self.inner.completion_shared() };
-        let len = cqe.len().min(entries.len());
-        for (iour_entry, entry) in cqe.zip(entries) {
-            entry.write(create_entry(iour_entry));
+    fn poll_entries(&self, entries: &mut [MaybeUninit<Entry>]) -> usize {
+        let len = self.cqueue.len().min(entries.len());
+        for entry in &mut entries[..len] {
+            entry.write(self.cqueue.pop().unwrap());
         }
         len
     }
@@ -66,7 +103,8 @@ impl Poller for Driver {
 
     unsafe fn push(&self, op: &mut impl OpCode, user_data: usize) -> io::Result<()> {
         let entry = op.create_entry().user_data(user_data as _);
-        self.push_entry(entry)
+        self.squeue.push(entry);
+        Ok(())
     }
 
     fn post(&self, user_data: usize, result: usize) -> io::Result<()> {
@@ -77,7 +115,8 @@ impl Poller for Driver {
             None,
         )
         .build();
-        unsafe { self.push_entry(entry) }
+        self.squeue.push(entry);
+        Ok(())
     }
 
     fn poll(
@@ -88,33 +127,17 @@ impl Poller for Driver {
         if entries.is_empty() {
             return Ok(0);
         }
-        let len = unsafe { self.poll_entries(entries) };
+        let len = self.poll_entries(entries);
         if len > 0 {
             return Ok(len);
         }
-        if let Some(duration) = timeout {
-            let timespec = timespec(duration);
-            let args = SubmitArgs::new().timespec(&timespec);
-            match self.inner.submitter().submit_with_args(1, &args) {
-                Ok(res) => Ok(res),
-                Err(e) => {
-                    if matches!(e.raw_os_error(), Some(libc::ETIME) | Some(libc::EINTR)) {
-                        Err(io::Error::new(io::ErrorKind::TimedOut, e))
-                    } else {
-                        Err(e)
-                    }
-                }
-            }?;
-        } else {
-            // Submit and Wait without timeout
-            self.inner.submit_and_wait(1)?;
-        }
-        let len = unsafe { self.poll_entries(entries) };
+        unsafe { self.submit(timeout) }?;
+        let len = self.poll_entries(entries);
         Ok(len)
     }
 }
 
-fn create_entry(entry: io_uring::cqueue::Entry) -> Entry {
+fn create_entry(entry: cqueue::Entry) -> Entry {
     let result = entry.result();
     let result = if result < 0 {
         Err(io::Error::from_raw_os_error(-result))

--- a/src/driver/iour/mod.rs
+++ b/src/driver/iour/mod.rs
@@ -7,7 +7,7 @@ use io_uring::{
     types::{Fd, SubmitArgs, Timespec},
     IoUring,
 };
-use std::{io, mem::MaybeUninit, time::Duration};
+use std::{cell::RefCell, io, marker::PhantomData, mem::MaybeUninit, time::Duration};
 
 pub use libc::{sockaddr_storage, socklen_t};
 pub use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -27,6 +27,7 @@ pub struct Driver {
     inner: IoUring,
     squeue: SegQueue<squeue::Entry>,
     cqueue: SegQueue<Entry>,
+    _p: PhantomData<RefCell<()>>,
 }
 
 impl Driver {
@@ -41,6 +42,7 @@ impl Driver {
             inner: IoUring::new(entries)?,
             squeue: SegQueue::default(),
             cqueue: SegQueue::default(),
+            _p: PhantomData,
         })
     }
 

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -78,6 +78,14 @@ pub trait Poller {
     unsafe fn push(&self, op: &mut (impl OpCode + 'static), user_data: usize) -> io::Result<()>;
 
     /// Post an operation result to the driver.
+    ///
+    /// ## Platform specific
+    ///
+    /// * IOCP: it will interrupt [`Poller::poll`].
+    /// [`Poller::poll`] will return successfully.
+    /// * io-uring: it won't interrupt [`Poller::poll`].
+    /// You need to send a signal to the polling thread to interrupt the driver.
+    /// [`Poller::poll`] will then return with [`io::ErrorKind::Interrupted`].
     fn post(&self, user_data: usize, result: usize) -> io::Result<()>;
 
     /// Poll the driver with an optional timeout.

--- a/src/task/runtime.rs
+++ b/src/task/runtime.rs
@@ -179,11 +179,10 @@ impl Runtime {
                         .update_result(entry.user_data(), entry.into_result());
                 }
             }
-            Err(e) => {
-                if e.kind() != io::ErrorKind::TimedOut {
-                    panic!("{:?}", e);
-                }
-            }
+            Err(e) => match e.kind() {
+                io::ErrorKind::TimedOut | io::ErrorKind::Interrupted => {}
+                _ => panic!("{:?}", e),
+            },
         }
         #[cfg(feature = "time")]
         self.timer_runtime.borrow_mut().wake();

--- a/src/task/time.rs
+++ b/src/task/time.rs
@@ -87,8 +87,10 @@ impl TimerRuntime {
         let elapsed = self.time.elapsed();
         while let Some(entry) = self.wheel.pop() {
             if entry.delay <= elapsed {
-                if let Some(waker) = self.tasks.remove(entry.key) {
-                    waker.wake();
+                if self.tasks.contains(entry.key) {
+                    if let Some(waker) = self.tasks.remove(entry.key) {
+                        waker.wake();
+                    }
                 }
             } else {
                 self.wheel.push(entry);


### PR DESCRIPTION
Fixes #11 

This is the easiest solution AFAIK. Maintain unbounded queues myself, and submit them in a loop. `SegQueue` is used because the linux signal may interrupt the thread and cause sync problems.

@redbaron Do you like this solution?