### PR TITLE
Style: add rustfmt.toml and reformat

### DIFF
--- a/examples/net.rs
+++ b/examples/net.rs
@@ -1,5 +1,6 @@
-use compio::net::{TcpListener, TcpStream};
 use std::net::Ipv4Addr;
+
+use compio::net::{TcpListener, TcpStream};
 
 fn main() {
     compio::task::block_on(async {

--- a/examples/tick.rs
+++ b/examples/tick.rs
@@ -1,6 +1,7 @@
+use std::time::Duration;
+
 use compio::{signal::ctrl_c, time::interval};
 use futures_util::{select, FutureExt};
-use std::time::Duration;
 
 fn main() {
     compio::task::block_on(async {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,19 @@
+unstable_features = true
+
+version = "Two"
+
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+reorder_imports = true
+
+wrap_comments = true
+normalize_comments = true
+
+reorder_impl_items = true
+condense_wildcard_suffixes = true
+enum_discrim_align_threshold = 20
+use_field_init_shorthand = true
+
+format_strings = true
+format_code_in_doc_comments = true
+format_macro_matchers = true

--- a/src/buf/buf_wrapper.rs
+++ b/src/buf/buf_wrapper.rs
@@ -1,8 +1,9 @@
-use crate::buf::*;
 use std::{
     io::{IoSlice, IoSliceMut},
     ops::{Deref, DerefMut},
 };
+
+use crate::buf::*;
 
 #[derive(Debug)]
 pub struct BufWrapper<T> {

--- a/src/buf/io_buf.rs
+++ b/src/buf/io_buf.rs
@@ -244,8 +244,8 @@ pub unsafe trait IoBufMut: IoBuf {
 
     /// Updates the number of initialized bytes.
     ///
-    /// The specified `len` plus [`IoBuf::buf_len`] becomes the new value returned by
-    /// [`IoBuf::buf_len`].
+    /// The specified `len` plus [`IoBuf::buf_len`] becomes the new value
+    /// returned by [`IoBuf::buf_len`].
     fn set_buf_init(&mut self, len: usize);
 }
 

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -1,8 +1,8 @@
 //! Utilities for working with buffers.
 //!
 //! IOCP APIs require passing ownership of buffers to the runtime. The
-//! crate defines [`IoBuf`] and [`IoBufMut`] traits which are implemented by buffer
-//! types that respect the IOCP contract.
+//! crate defines [`IoBuf`] and [`IoBufMut`] traits which are implemented by
+//! buffer types that respect the IOCP contract.
 
 mod io_buf;
 pub use io_buf::*;

--- a/src/buf/slice.rs
+++ b/src/buf/slice.rs
@@ -1,5 +1,6 @@
-use crate::buf::*;
 use std::ops::{Deref, DerefMut};
+
+use crate::buf::*;
 
 /// An owned view into a contiguous sequence of bytes.
 ///

--- a/src/buf/with_buf.rs
+++ b/src/buf/with_buf.rs
@@ -1,8 +1,9 @@
-use crate::buf::IntoInner;
 use std::{
     io::{IoSlice, IoSliceMut},
     ops::{Deref, DerefMut},
 };
+
+use crate::buf::IntoInner;
 
 pub trait WrapBuf: IntoInner {
     fn new(buffer: Self::Inner) -> Self;

--- a/src/driver/iocp/fs.rs
+++ b/src/driver/iocp/fs.rs
@@ -1,4 +1,3 @@
-use crate::driver::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::{
     io,
     os::windows::prelude::{
@@ -6,7 +5,10 @@ use std::{
     },
     path::Path,
 };
+
 use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OVERLAPPED;
+
+use crate::driver::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
 pub struct FileInner {
     handle: OwnedHandle,

--- a/src/driver/iocp/mod.rs
+++ b/src/driver/iocp/mod.rs
@@ -1,5 +1,3 @@
-use crate::driver::{Entry, Poller};
-use crossbeam_queue::SegQueue;
 use std::{
     ffi::c_void,
     io,
@@ -12,6 +10,8 @@ use std::{
     task::Poll,
     time::Duration,
 };
+
+use crossbeam_queue::SegQueue;
 use windows_sys::Win32::{
     Foundation::{
         RtlNtStatusToDosError, FACILITY_NTWIN32, INVALID_HANDLE_VALUE, NTSTATUS, STATUS_PENDING,
@@ -27,6 +27,8 @@ use windows_sys::Win32::{
         },
     },
 };
+
+use crate::driver::{Entry, Poller};
 
 pub(crate) mod fs;
 pub(crate) mod net;

--- a/src/driver/iocp/net.rs
+++ b/src/driver/iocp/net.rs
@@ -1,8 +1,9 @@
+use std::os::windows::prelude::{AsRawSocket, FromRawSocket, IntoRawSocket};
+
 use crate::{
     driver::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
     net::Socket,
 };
-use std::os::windows::prelude::{AsRawSocket, FromRawSocket, IntoRawSocket};
 
 impl AsRawFd for Socket {
     fn as_raw_fd(&self) -> RawFd {

--- a/src/driver/iocp/op.rs
+++ b/src/driver/iocp/op.rs
@@ -1,15 +1,11 @@
-use crate::{
-    buf::{AsIoSlices, AsIoSlicesMut, IntoInner, IoBuf, IoBufMut},
-    driver::{OpCode, RawFd},
-    op::*,
-};
-use once_cell::sync::OnceCell as OnceLock;
-use socket2::SockAddr;
 use std::{
     io,
     ptr::{null, null_mut},
     task::Poll,
 };
+
+use once_cell::sync::OnceCell as OnceLock;
+use socket2::SockAddr;
 use windows_sys::{
     core::GUID,
     Win32::{
@@ -26,6 +22,12 @@ use windows_sys::{
         Storage::FileSystem::{ReadFile, WriteFile},
         System::{Pipes::ConnectNamedPipe, IO::OVERLAPPED},
     },
+};
+
+use crate::{
+    buf::{AsIoSlices, AsIoSlicesMut, IntoInner, IoBuf, IoBufMut},
+    driver::{OpCode, RawFd},
+    op::*,
 };
 
 unsafe fn winapi_result(transferred: u32) -> Poll<io::Result<usize>> {
@@ -48,8 +50,8 @@ unsafe fn win32_result(res: i32, transferred: u32) -> Poll<io::Result<usize>> {
     }
 }
 
-// read, write, send and recv functions may return immediately, indicate that the task is
-// completed, but the overlapped result is also posted to the IOCP.
+// read, write, send and recv functions may return immediately, indicate that
+// the task is completed, but the overlapped result is also posted to the IOCP.
 // To make our driver easy, simply return Pending and query the result later.
 
 unsafe fn win32_pending_result(res: i32) -> Poll<io::Result<usize>> {

--- a/src/driver/iour/fs.rs
+++ b/src/driver/iour/fs.rs
@@ -1,5 +1,6 @@
-use crate::driver::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::{io, path::Path};
+
+use crate::driver::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
 pub struct FileInner {
     file: std::fs::File,

--- a/src/driver/iour/mod.rs
+++ b/src/driver/iour/mod.rs
@@ -1,15 +1,16 @@
-use crate::driver::{Entry, Poller};
+#[doc(no_inline)]
+pub use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use std::{cell::RefCell, io, marker::PhantomData, mem::MaybeUninit, time::Duration};
+
 use crossbeam_queue::SegQueue;
 use io_uring::{
     cqueue, squeue,
     types::{SubmitArgs, Timespec},
     IoUring,
 };
-use std::{cell::RefCell, io, marker::PhantomData, mem::MaybeUninit, time::Duration};
-
 pub(crate) use libc::{sockaddr_storage, socklen_t};
-#[doc(no_inline)]
-pub use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+
+use crate::driver::{Entry, Poller};
 
 pub(crate) mod fs;
 pub(crate) mod net;

--- a/src/driver/iour/op.rs
+++ b/src/driver/iour/op.rs
@@ -1,12 +1,14 @@
+use std::io::{IoSlice, IoSliceMut};
+
+use io_uring::{opcode, squeue::Entry, types::Fd};
+use libc::{sockaddr_storage, socklen_t};
+use socket2::SockAddr;
+
 use crate::{
     buf::{AsIoSlices, AsIoSlicesMut, IntoInner, IoBuf, IoBufMut, OneOrVec},
     driver::{OpCode, RawFd},
     op::*,
 };
-use io_uring::{opcode, squeue::Entry, types::Fd};
-use libc::{sockaddr_storage, socklen_t};
-use socket2::SockAddr;
-use std::io::{IoSlice, IoSliceMut};
 
 impl<T: IoBufMut> OpCode for ReadAt<T> {
     fn create_entry(&mut self) -> Entry {

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -21,13 +21,14 @@ cfg_if::cfg_if! {
 /// # Examples
 ///
 /// ```
+/// use std::net::SocketAddr;
+///
 /// use compio::{
 ///     buf::IntoInner,
 ///     driver::{AsRawFd, Driver, Poller},
 ///     net::UdpSocket,
 ///     op,
 /// };
-/// use std::net::SocketAddr;
 ///
 /// let first_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 /// let second_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
@@ -90,7 +91,8 @@ pub trait Poller {
 
     /// Poll the driver with an optional timeout.
     ///
-    /// If there are already tasks completed, this method will return immediately.
+    /// If there are already tasks completed, this method will return
+    /// immediately.
     ///
     /// If there are no tasks completed, this call will block and wait.
     /// If no timeout specified, it will block forever.

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -1,7 +1,3 @@
-use crate::{
-    driver::{fs::FileInner, AsRawFd, FromRawFd, IntoRawFd, RawFd},
-    fs::OpenOptions,
-};
 use std::{io, path::Path};
 
 #[cfg(feature = "runtime")]
@@ -10,6 +6,10 @@ use crate::{
     op::{BufResultExt, ReadAt, WriteAt},
     task::RUNTIME,
     BufResult,
+};
+use crate::{
+    driver::{fs::FileInner, AsRawFd, FromRawFd, IntoRawFd, RawFd},
+    fs::OpenOptions,
 };
 
 /// A reference to an open file on the filesystem.

--- a/src/fs/open_options.rs
+++ b/src/fs/open_options.rs
@@ -1,5 +1,6 @@
-use crate::fs::File;
 use std::{fs::OpenOptions as StdOpenOptions, io, path::Path};
+
+use crate::fs::File;
 
 /// Options and flags which can be used to configure how a file is opened.
 ///
@@ -11,8 +12,8 @@ use std::{fs::OpenOptions as StdOpenOptions, io, path::Path};
 /// Generally speaking, when using `OpenOptions`, you'll first call
 /// [`OpenOptions::new`], then chain calls to methods to set each option, then
 /// call [`OpenOptions::open`], passing the path of the file you're trying to
-/// open. This will give you a [`std::io::Result`] with a [`File`] inside that you
-/// can further operate on.
+/// open. This will give you a [`std::io::Result`] with a [`File`] inside that
+/// you can further operate on.
 ///
 /// # Examples
 ///
@@ -31,11 +32,11 @@ use std::{fs::OpenOptions as StdOpenOptions, io, path::Path};
 /// use compio::fs::OpenOptions;
 ///
 /// let file = OpenOptions::new()
-///             .read(true)
-///             .write(true)
-///             .create(true)
-///             .open("foo.txt")
-///             .unwrap();
+///     .read(true)
+///     .write(true)
+///     .create(true)
+///     .open("foo.txt")
+///     .unwrap();
 /// ```
 #[derive(Debug, Clone)]
 pub struct OpenOptions(pub(crate) StdOpenOptions);
@@ -79,7 +80,8 @@ impl OpenOptions {
 
     /// Sets the option to create a new file, or open it if it already exists.
     ///
-    /// In order for the file to be created, [`OpenOptions::write`] access must be used.
+    /// In order for the file to be created, [`OpenOptions::write`] access must
+    /// be used.
     pub fn create(mut self, create: bool) -> Self {
         self.0.create(create);
         self
@@ -87,8 +89,9 @@ impl OpenOptions {
 
     /// Sets the option to create a new file, failing if it already exists.
     ///
-    /// No file is allowed to exist at the target location, also no (dangling) symlink. In this
-    /// way, if the call succeeds, the file returned is guaranteed to be new.
+    /// No file is allowed to exist at the target location, also no (dangling)
+    /// symlink. In this way, if the call succeeds, the file returned is
+    /// guaranteed to be new.
     ///
     /// This option is useful because it is atomic. Otherwise between checking
     /// whether a file exists and creating a new one, the file may have been

--- a/src/named_pipe.rs
+++ b/src/named_pipe.rs
@@ -2,7 +2,6 @@
 //!
 //! The infrastructure of the code comes from tokio.
 
-use crate::driver::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::{
     ffi::{c_void, OsStr},
     io,
@@ -11,6 +10,7 @@ use std::{
     },
     ptr::null_mut,
 };
+
 use widestring::U16CString;
 use windows_sys::Win32::{
     Foundation::{GENERIC_READ, GENERIC_WRITE},
@@ -30,6 +30,7 @@ use windows_sys::Win32::{
     },
 };
 
+use crate::driver::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(feature = "runtime")]
 use crate::{
     buf::*,
@@ -55,6 +56,7 @@ use crate::{
 ///
 /// ```no_run
 /// use std::io;
+///
 /// use compio::named_pipe::ServerOptions;
 ///
 /// const PIPE_NAME: &str = r"\\.\pipe\named-pipe-idiomatic-server";
@@ -84,7 +86,7 @@ use crate::{
 ///         server = ServerOptions::new().create(PIPE_NAME)?;
 ///
 ///         let client = compio::task::spawn(async move {
-///             /* use the connected client */
+///             // use the connected client
 /// #           Ok::<_, std::io::Error>(())
 ///         });
 /// #       if true { break } // needed for type inference to work
@@ -93,7 +95,7 @@ use crate::{
 ///     Ok::<_, io::Error>(())
 /// });
 ///
-/// /* do something else not server related here */
+/// // do something else not server related here
 /// # Ok(()) }
 /// ```
 ///
@@ -145,8 +147,8 @@ impl NamedPipeServer {
     /// # Cancel safety
     ///
     /// This method is cancellation safe in the sense that if it is used as the
-    /// event in a [`select!`](futures_util::select) statement and some other branch
-    /// completes first, then no connection events have been lost.
+    /// event in a [`select!`](futures_util::select) statement and some other
+    /// branch completes first, then no connection events have been lost.
     ///
     /// [`ConnectNamedPipe`]: https://docs.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-connectnamedpipe
     ///
@@ -183,13 +185,9 @@ impl NamedPipeServer {
     /// const PIPE_NAME: &str = r"\\.\pipe\tokio-named-pipe-disconnect";
     ///
     /// # compio::task::block_on(async move {
-    /// let server = ServerOptions::new()
-    ///     .create(PIPE_NAME)
-    ///     .unwrap();
+    /// let server = ServerOptions::new().create(PIPE_NAME).unwrap();
     ///
-    /// let mut client = ClientOptions::new()
-    ///     .open(PIPE_NAME)
-    ///     .unwrap();
+    /// let mut client = ClientOptions::new().open(PIPE_NAME).unwrap();
     ///
     /// // Wait for a client to become connected.
     /// server.connect().await.unwrap();
@@ -272,6 +270,7 @@ impl IntoRawFd for NamedPipeServer {
 ///
 /// ```no_run
 /// use std::time::Duration;
+///
 /// use compio::{named_pipe::ClientOptions, time};
 /// use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
 ///
@@ -288,7 +287,7 @@ impl IntoRawFd for NamedPipeServer {
 ///     time::sleep(Duration::from_millis(50)).await;
 /// };
 ///
-/// /* use the connected client */
+/// // use the connected client
 /// # Ok(()) });
 /// ```
 ///
@@ -315,8 +314,7 @@ impl NamedPipeClient {
     /// const PIPE_NAME: &str = r"\\.\pipe\tokio-named-pipe-client-info";
     ///
     /// # compio::task::block_on(async move {
-    /// let client = ClientOptions::new()
-    ///     .open(PIPE_NAME)?;
+    /// let client = ClientOptions::new().open(PIPE_NAME)?;
     ///
     /// let client_info = client.info()?;
     ///
@@ -433,7 +431,8 @@ impl ServerOptions {
     /// The default pipe mode is [`PipeMode::Byte`]. See [`PipeMode`] for
     /// documentation of what each mode means.
     ///
-    /// This corresponds to specifying `PIPE_TYPE_` and `PIPE_READMODE_` in  [`dwPipeMode`].
+    /// This corresponds to specifying `PIPE_TYPE_` and `PIPE_READMODE_` in
+    /// [`dwPipeMode`].
     ///
     /// [`dwPipeMode`]: https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createnamedpipea
     pub fn pipe_mode(&mut self, pipe_mode: PipeMode) -> &mut Self {
@@ -455,6 +454,7 @@ impl ServerOptions {
     ///
     /// ```
     /// use std::io;
+    ///
     /// use compio::named_pipe::{ClientOptions, ServerOptions};
     ///
     /// const PIPE_NAME: &str = r"\\.\pipe\tokio-named-pipe-access-inbound-err1";
@@ -465,9 +465,7 @@ impl ServerOptions {
     ///     .create(PIPE_NAME)
     ///     .unwrap();
     ///
-    /// let e = ClientOptions::new()
-    ///     .open(PIPE_NAME)
-    ///     .unwrap_err();
+    /// let e = ClientOptions::new().open(PIPE_NAME).unwrap_err();
     ///
     /// assert_eq!(e.kind(), io::ErrorKind::PermissionDenied);
     /// # })
@@ -478,6 +476,7 @@ impl ServerOptions {
     ///
     /// ```
     /// use std::io;
+    ///
     /// use compio::named_pipe::{ClientOptions, ServerOptions};
     ///
     /// const PIPE_NAME: &str = r"\\.\pipe\tokio-named-pipe-access-inbound-err2";
@@ -488,10 +487,7 @@ impl ServerOptions {
     ///     .create(PIPE_NAME)
     ///     .unwrap();
     ///
-    /// let mut client = ClientOptions::new()
-    ///     .write(false)
-    ///     .open(PIPE_NAME)
-    ///     .unwrap();
+    /// let mut client = ClientOptions::new().write(false).open(PIPE_NAME).unwrap();
     ///
     /// server.connect().await.unwrap();
     ///
@@ -507,6 +503,7 @@ impl ServerOptions {
     ///
     /// ```
     /// use std::io;
+    ///
     /// use compio::named_pipe::{ClientOptions, ServerOptions};
     ///
     /// const PIPE_NAME: &str = r"\\.\pipe\tokio-named-pipe-access-inbound";
@@ -517,10 +514,7 @@ impl ServerOptions {
     ///     .create(PIPE_NAME)
     ///     .unwrap();
     ///
-    /// let mut client = ClientOptions::new()
-    ///     .write(false)
-    ///     .open(PIPE_NAME)
-    ///     .unwrap();
+    /// let mut client = ClientOptions::new().write(false).open(PIPE_NAME).unwrap();
     ///
     /// server.connect().await.unwrap();
     ///
@@ -556,6 +550,7 @@ impl ServerOptions {
     ///
     /// ```
     /// use std::io;
+    ///
     /// use compio::named_pipe::{ClientOptions, ServerOptions};
     ///
     /// const PIPE_NAME: &str = r"\\.\pipe\tokio-named-pipe-access-outbound-err1";
@@ -566,9 +561,7 @@ impl ServerOptions {
     ///     .create(PIPE_NAME)
     ///     .unwrap();
     ///
-    /// let e = ClientOptions::new()
-    ///     .open(PIPE_NAME)
-    ///     .unwrap_err();
+    /// let e = ClientOptions::new().open(PIPE_NAME).unwrap_err();
     ///
     /// assert_eq!(e.kind(), io::ErrorKind::PermissionDenied);
     /// # })
@@ -579,6 +572,7 @@ impl ServerOptions {
     ///
     /// ```
     /// use std::io;
+    ///
     /// use compio::named_pipe::{ClientOptions, ServerOptions};
     ///
     /// const PIPE_NAME: &str = r"\\.\pipe\tokio-named-pipe-access-outbound-err2";
@@ -589,10 +583,7 @@ impl ServerOptions {
     ///     .create(PIPE_NAME)
     ///     .unwrap();
     ///
-    /// let mut client = ClientOptions::new()
-    ///     .read(false)
-    ///     .open(PIPE_NAME)
-    ///     .unwrap();
+    /// let mut client = ClientOptions::new().read(false).open(PIPE_NAME).unwrap();
     ///
     /// server.connect().await.unwrap();
     ///
@@ -618,10 +609,7 @@ impl ServerOptions {
     ///     .create(PIPE_NAME)
     ///     .unwrap();
     ///
-    /// let mut client = ClientOptions::new()
-    ///     .read(false)
-    ///     .open(PIPE_NAME)
-    ///     .unwrap();
+    /// let mut client = ClientOptions::new().read(false).open(PIPE_NAME).unwrap();
     ///
     /// server.connect().await.unwrap();
     ///
@@ -665,6 +653,7 @@ impl ServerOptions {
     ///
     /// ```
     /// use std::io;
+    ///
     /// use compio::named_pipe::ServerOptions;
     ///
     /// const PIPE_NAME: &str = r"\\.\pipe\tokio-named-pipe-first-instance-error";
@@ -689,6 +678,7 @@ impl ServerOptions {
     ///
     /// ```
     /// use std::io;
+    ///
     /// use compio::named_pipe::ServerOptions;
     ///
     /// const PIPE_NAME: &str = r"\\.\pipe\tokio-named-pipe-first-instance";
@@ -714,7 +704,8 @@ impl ServerOptions {
         self
     }
 
-    /// Requests permission to modify the pipe's discretionary access control list.
+    /// Requests permission to modify the pipe's discretionary access control
+    /// list.
     ///
     /// This corresponds to setting [`WRITE_DAC`] in dwOpenMode.
     ///
@@ -754,7 +745,6 @@ impl ServerOptions {
     ///
     /// # })
     /// ```
-    ///
     /// ```
     /// use std::{io, ptr};
     //
@@ -789,7 +779,7 @@ impl ServerOptions {
     ///
     /// # })
     /// ```
-    ///
+    /// 
     /// [`WRITE_DAC`]: https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createnamedpipea
     pub fn write_dac(&mut self, requested: bool) -> &mut Self {
         self.write_dac = requested;
@@ -844,7 +834,8 @@ impl ServerOptions {
     ///
     /// ```
     /// use std::io;
-    /// use compio::named_pipe::{ServerOptions, ClientOptions};
+    ///
+    /// use compio::named_pipe::{ClientOptions, ServerOptions};
     /// use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
     ///
     /// const PIPE_NAME: &str = r"\\.\pipe\tokio-named-pipe-max-instances";
@@ -1030,7 +1021,7 @@ impl ClientOptions {
     /// Creates a new named pipe builder with the default settings.
     ///
     /// ```
-    /// use compio::named_pipe::{ServerOptions, ClientOptions};
+    /// use compio::named_pipe::{ClientOptions, ServerOptions};
     ///
     /// const PIPE_NAME: &str = r"\\.\pipe\tokio-named-pipe-client-new";
     ///
@@ -1051,7 +1042,8 @@ impl ClientOptions {
 
     /// If the client supports reading data. This is enabled by default.
     ///
-    /// This corresponds to setting [`GENERIC_READ`] in the call to [`CreateFile`].
+    /// This corresponds to setting [`GENERIC_READ`] in the call to
+    /// [`CreateFile`].
     ///
     /// [`GENERIC_READ`]: https://docs.microsoft.com/en-us/windows/win32/secauthz/generic-access-rights
     /// [`CreateFile`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
@@ -1062,7 +1054,8 @@ impl ClientOptions {
 
     /// If the created pipe supports writing data. This is enabled by default.
     ///
-    /// This corresponds to setting [`GENERIC_WRITE`] in the call to [`CreateFile`].
+    /// This corresponds to setting [`GENERIC_WRITE`] in the call to
+    /// [`CreateFile`].
     ///
     /// [`GENERIC_WRITE`]: https://docs.microsoft.com/en-us/windows/win32/secauthz/generic-access-rights
     /// [`CreateFile`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
@@ -1122,8 +1115,8 @@ impl ClientOptions {
     /// * [`std::io::ErrorKind::NotFound`] - This indicates that the named pipe
     ///   does not exist. Presumably the server is not up.
     /// * [`ERROR_PIPE_BUSY`] - This error is raised when the named pipe exists,
-    ///   but the server is not currently waiting for a connection. Please see the
-    ///   examples for how to check for this error.
+    ///   but the server is not currently waiting for a connection. Please see
+    ///   the examples for how to check for this error.
     ///
     /// [`ERROR_PIPE_BUSY`]: https://docs.rs/windows-sys/latest/windows_sys/Win32/Foundation/constant.ERROR_PIPE_BUSY.html
     ///
@@ -1132,6 +1125,7 @@ impl ClientOptions {
     ///
     /// ```no_run
     /// use std::time::Duration;
+    ///
     /// use compio::{named_pipe::ClientOptions, time};
     /// use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
     ///

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -12,14 +12,14 @@ mod udp;
 pub use udp::*;
 
 mod unix;
-pub use unix::*;
-
-use socket2::SockAddr;
 use std::{
     future::Future,
     io,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs},
 };
+
+use socket2::SockAddr;
+pub use unix::*;
 
 /// A trait for objects which can be converted or resolved to one or more
 /// [`SockAddr`] values.
@@ -60,6 +60,7 @@ itsafisa!((String, u16));
 
 impl ToSockAddrs for (&str, u16) {
     type Iter = std::iter::Map<std::vec::IntoIter<SocketAddr>, fn(SocketAddr) -> SockAddr>;
+
     fn to_sock_addrs(&self) -> io::Result<Self::Iter> {
         ToSocketAddrs::to_socket_addrs(self).map(|iter| iter.map(SockAddr::from as _))
     }

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -1,5 +1,6 @@
-use socket2::{Domain, Protocol, SockAddr, Socket as Socket2, Type};
 use std::{io, net::Shutdown};
+
+use socket2::{Domain, Protocol, SockAddr, Socket as Socket2, Type};
 
 #[cfg(feature = "runtime")]
 use crate::{
@@ -55,11 +56,12 @@ impl Socket {
     #[cfg(target_os = "windows")]
     #[allow(dead_code)]
     pub fn protocol(&self) -> io::Result<Option<Protocol>> {
-        #[allow(unused_imports)]
-        use crate::driver::AsRawFd;
         use windows_sys::Win32::Networking::WinSock::{
             getsockopt, SOL_SOCKET, SO_PROTOCOL_INFO, WSAPROTOCOL_INFOW,
         };
+
+        #[allow(unused_imports)]
+        use crate::driver::AsRawFd;
 
         let mut info: WSAPROTOCOL_INFOW = unsafe { std::mem::zeroed() };
         let mut info_len = std::mem::size_of_val(&info) as _;

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -1,21 +1,23 @@
-use crate::net::{Socket, *};
-use socket2::{Protocol, Type};
 use std::net::Shutdown;
 
+use socket2::{Protocol, Type};
+
+use crate::net::{Socket, *};
 #[cfg(feature = "runtime")]
 use crate::{buf::*, *};
 
 /// A TCP socket server, listening for connections.
 ///
-/// You can accept a new connection by using the [`accept`](`TcpListener::accept`)
-/// method.
+/// You can accept a new connection by using the
+/// [`accept`](`TcpListener::accept`) method.
 ///
 /// # Examples
 ///
 /// ```
+/// use std::net::SocketAddr;
+///
 /// use compio::net::{TcpListener, TcpStream};
 /// use socket2::SockAddr;
-/// use std::net::SocketAddr;
 ///
 /// let addr: SockAddr = "127.0.0.1:2345".parse::<SocketAddr>().unwrap().into();
 ///
@@ -40,7 +42,8 @@ pub struct TcpListener {
 }
 
 impl TcpListener {
-    /// Creates a new `TcpListener`, which will be bound to the specified address.
+    /// Creates a new `TcpListener`, which will be bound to the specified
+    /// address.
     ///
     /// The returned listener is ready for accepting connections.
     ///
@@ -75,13 +78,20 @@ impl TcpListener {
     ///
     /// ```
     /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+    ///
     /// use compio::net::TcpListener;
     /// use socket2::SockAddr;
     ///
     /// let listener = TcpListener::bind("127.0.0.1:8080").unwrap();
     ///
     /// let addr = listener.local_addr().expect("Couldn't get local address");
-    /// assert_eq!(addr, SockAddr::from(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080))));
+    /// assert_eq!(
+    ///     addr,
+    ///     SockAddr::from(SocketAddr::V4(SocketAddrV4::new(
+    ///         Ipv4Addr::new(127, 0, 0, 1),
+    ///         8080
+    ///     )))
+    /// );
     /// ```
     pub fn local_addr(&self) -> io::Result<SockAddr> {
         self.inner.local_addr()
@@ -98,8 +108,9 @@ impl_raw_fd!(TcpListener, inner);
 /// # Examples
 ///
 /// ```no_run
-/// use compio::net::TcpStream;
 /// use std::net::SocketAddr;
+///
+/// use compio::net::TcpStream;
 ///
 /// compio::task::block_on(async {
 ///     // Connect to a peer
@@ -148,15 +159,15 @@ impl TcpStream {
         self.inner.shutdown(how)
     }
 
-    /// Receives a packet of data from the socket into the buffer, returning the original buffer and
-    /// quantity of data received.
+    /// Receives a packet of data from the socket into the buffer, returning the
+    /// original buffer and quantity of data received.
     #[cfg(feature = "runtime")]
     pub async fn recv<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.recv(buffer).await
     }
 
-    /// Sends some data to the socket from the buffer, returning the original buffer and
-    /// quantity of data sent.
+    /// Sends some data to the socket from the buffer, returning the original
+    /// buffer and quantity of data sent.
     #[cfg(feature = "runtime")]
     pub async fn send<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.send(buffer).await

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,25 +1,30 @@
-use crate::net::{Socket, *};
 use socket2::{Protocol, Type};
 
+use crate::net::{Socket, *};
 #[cfg(feature = "runtime")]
 use crate::{buf::*, *};
 
 /// A UDP socket.
 ///
-/// UDP is "connectionless", unlike TCP. Meaning, regardless of what address you've bound to, a `UdpSocket`
-/// is free to communicate with many different remotes. There are basically two main ways to use `UdpSocket`:
+/// UDP is "connectionless", unlike TCP. Meaning, regardless of what address
+/// you've bound to, a `UdpSocket` is free to communicate with many different
+/// remotes. There are basically two main ways to use `UdpSocket`:
 ///
-/// * one to many: [`bind`](`UdpSocket::bind`) and use [`send_to`](`UdpSocket::send_to`)
-///   and [`recv_from`](`UdpSocket::recv_from`) to communicate with many different addresses
-/// * one to one: [`connect`](`UdpSocket::connect`) and associate with a single address, using [`send`](`UdpSocket::send`)
-///   and [`recv`](`UdpSocket::recv`) to communicate only with that remote address
+/// * one to many: [`bind`](`UdpSocket::bind`) and use
+///   [`send_to`](`UdpSocket::send_to`) and
+///   [`recv_from`](`UdpSocket::recv_from`) to communicate with many different
+///   addresses
+/// * one to one: [`connect`](`UdpSocket::connect`) and associate with a single
+///   address, using [`send`](`UdpSocket::send`) and [`recv`](`UdpSocket::recv`)
+///   to communicate only with that remote address
 ///
 /// # Examples
 /// Bind and connect a pair of sockets and send a packet:
 ///
 /// ```
-/// use compio::net::UdpSocket;
 /// use std::net::SocketAddr;
+///
+/// use compio::net::UdpSocket;
 ///
 /// compio::task::block_on(async {
 ///     let first_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
@@ -52,8 +57,9 @@ use crate::{buf::*, *};
 /// Send and receive packets without connecting:
 ///
 /// ```
-/// use compio::net::UdpSocket;
 /// use std::net::SocketAddr;
+///
+/// use compio::net::UdpSocket;
 /// use socket2::SockAddr;
 ///
 /// compio::task::block_on(async {
@@ -69,7 +75,9 @@ use crate::{buf::*, *};
 ///     let buf = Vec::with_capacity(32);
 ///
 ///     // write data
-///     let (result, _) = socket.send_to("hello world", SockAddr::from(second_addr)).await;
+///     let (result, _) = socket
+///         .send_to("hello world", SockAddr::from(second_addr))
+///         .await;
 ///     result.unwrap();
 ///
 ///     // read data
@@ -106,19 +114,28 @@ impl UdpSocket {
         super::each_addr(addr, |addr| self.inner.connect(&addr))
     }
 
-    /// Returns the socket address of the remote peer this socket was connected to.
+    /// Returns the socket address of the remote peer this socket was connected
+    /// to.
     ///
     /// # Examples
     ///
     /// ```no_run
-    /// use compio::net::UdpSocket;
     /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+    ///
+    /// use compio::net::UdpSocket;
     /// use socket2::SockAddr;
     ///
     /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
-    /// socket.connect("192.168.0.1:41203").expect("couldn't connect to address");
-    /// assert_eq!(socket.peer_addr().unwrap(),
-    ///            SockAddr::from(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 0, 1), 41203))));
+    /// socket
+    ///     .connect("192.168.0.1:41203")
+    ///     .expect("couldn't connect to address");
+    /// assert_eq!(
+    ///     socket.peer_addr().unwrap(),
+    ///     SockAddr::from(SocketAddr::V4(SocketAddrV4::new(
+    ///         Ipv4Addr::new(192, 168, 0, 1),
+    ///         41203
+    ///     )))
+    /// );
     /// ```
     pub fn peer_addr(&self) -> io::Result<SockAddr> {
         self.inner.peer_addr()
@@ -129,8 +146,9 @@ impl UdpSocket {
     /// # Example
     ///
     /// ```
-    /// use compio::net::UdpSocket;
     /// use std::net::SocketAddr;
+    ///
+    /// use compio::net::UdpSocket;
     /// use socket2::SockAddr;
     ///
     /// let addr: SockAddr = "127.0.0.1:8080".parse::<SocketAddr>().unwrap().into();
@@ -143,29 +161,29 @@ impl UdpSocket {
         self.inner.local_addr()
     }
 
-    /// Receives a packet of data from the socket into the buffer, returning the original buffer and
-    /// quantity of data received.
+    /// Receives a packet of data from the socket into the buffer, returning the
+    /// original buffer and quantity of data received.
     #[cfg(feature = "runtime")]
     pub async fn recv<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.recv(buffer).await
     }
 
-    /// Receives a packet of data from the socket into the buffer, returning the original buffer and
-    /// quantity of data received.
+    /// Receives a packet of data from the socket into the buffer, returning the
+    /// original buffer and quantity of data received.
     #[cfg(feature = "runtime")]
     pub async fn recv_vectored<T: IoBufMut>(&self, buffer: Vec<T>) -> BufResult<usize, Vec<T>> {
         self.inner.recv_vectored(buffer).await
     }
 
-    /// Sends some data to the socket from the buffer, returning the original buffer and
-    /// quantity of data sent.
+    /// Sends some data to the socket from the buffer, returning the original
+    /// buffer and quantity of data sent.
     #[cfg(feature = "runtime")]
     pub async fn send<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.send(buffer).await
     }
 
-    /// Sends some data to the socket from the buffer, returning the original buffer and
-    /// quantity of data sent.
+    /// Sends some data to the socket from the buffer, returning the original
+    /// buffer and quantity of data sent.
     #[cfg(feature = "runtime")]
     pub async fn send_vectored<T: IoBuf>(&self, buffer: Vec<T>) -> BufResult<usize, Vec<T>> {
         self.inner.send_vectored(buffer).await

--- a/src/net/unix.rs
+++ b/src/net/unix.rs
@@ -1,13 +1,15 @@
-use crate::net::{Socket, *};
-use socket2::{Domain, Type};
 use std::{net::Shutdown, path::Path};
 
+use socket2::{Domain, Type};
+
+use crate::net::{Socket, *};
 #[cfg(feature = "runtime")]
 use crate::{buf::*, *};
 
 /// A Unix socket server, listening for connections.
 ///
-/// You can accept a new connection by using the [`UnixListener::accept`] method.
+/// You can accept a new connection by using the [`UnixListener::accept`]
+/// method.
 ///
 /// # Examples
 ///
@@ -37,14 +39,16 @@ pub struct UnixListener {
 }
 
 impl UnixListener {
-    /// Creates a new [`UnixListener`], which will be bound to the specified file path.
-    /// The file path cannot yet exist, and will be cleaned up upon dropping [`UnixListener`]
+    /// Creates a new [`UnixListener`], which will be bound to the specified
+    /// file path. The file path cannot yet exist, and will be cleaned up
+    /// upon dropping [`UnixListener`]
     pub fn bind(path: impl AsRef<Path>) -> io::Result<Self> {
         Self::bind_addr(SockAddr::unix(path)?)
     }
 
-    /// Creates a new [`UnixListener`] with [`SockAddr`], which will be bound to the specified file path.
-    /// The file path cannot yet exist, and will be cleaned up upon dropping [`UnixListener`]
+    /// Creates a new [`UnixListener`] with [`SockAddr`], which will be bound to
+    /// the specified file path. The file path cannot yet exist, and will be
+    /// cleaned up upon dropping [`UnixListener`]
     pub fn bind_addr(addr: impl ToSockAddrs) -> io::Result<Self> {
         each_addr(addr, |addr| {
             let socket = Socket::bind(&addr, Type::STREAM, None)?;
@@ -98,15 +102,15 @@ pub struct UnixStream {
 
 impl UnixStream {
     /// Opens a Unix connection to the specified file path. There must be a
-    /// [`UnixListener`] or equivalent listening on the corresponding Unix domain socket
-    /// to successfully connect and return a `UnixStream`.
+    /// [`UnixListener`] or equivalent listening on the corresponding Unix
+    /// domain socket to successfully connect and return a `UnixStream`.
     pub fn connect(path: impl AsRef<Path>) -> io::Result<Self> {
         Self::connect_addr(SockAddr::unix(path)?)
     }
 
     /// Opens a Unix connection to the specified address. There must be a
-    /// [`UnixListener`] or equivalent listening on the corresponding Unix domain socket
-    /// to successfully connect and return a `UnixStream`.
+    /// [`UnixListener`] or equivalent listening on the corresponding Unix
+    /// domain socket to successfully connect and return a `UnixStream`.
     pub fn connect_addr(addr: impl ToSockAddrs) -> io::Result<Self> {
         each_addr(addr, |addr| {
             let socket = Socket::new(Domain::UNIX, Type::STREAM, None)?;
@@ -135,15 +139,15 @@ impl UnixStream {
         self.inner.shutdown(how)
     }
 
-    /// Receives a packet of data from the socket into the buffer, returning the original buffer and
-    /// quantity of data received.
+    /// Receives a packet of data from the socket into the buffer, returning the
+    /// original buffer and quantity of data received.
     #[cfg(feature = "runtime")]
     pub async fn recv<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.recv(buffer).await
     }
 
-    /// Sends some data to the socket from the buffer, returning the original buffer and
-    /// quantity of data sent.
+    /// Sends some data to the socket from the buffer, returning the original
+    /// buffer and quantity of data sent.
     #[cfg(feature = "runtime")]
     pub async fn send<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.send(buffer).await

--- a/src/op.rs
+++ b/src/op.rs
@@ -3,6 +3,10 @@
 //! The operation itself doesn't perform anything.
 //! You need to pass them to [`crate::driver::Driver`], and poll the driver.
 
+use std::io::{IoSlice, IoSliceMut};
+
+use socket2::SockAddr;
+
 use crate::{
     buf::{
         AsIoSlices, AsIoSlicesMut, BufWrapper, IntoInner, IoBuf, IoBufMut, OneOrVec,
@@ -11,8 +15,6 @@ use crate::{
     driver::{sockaddr_storage, socklen_t, RawFd},
     BufResult,
 };
-use socket2::SockAddr;
-use std::io::{IoSlice, IoSliceMut};
 
 pub(crate) trait BufResultExt {
     fn map_advanced(self) -> Self;
@@ -56,10 +58,9 @@ impl<T> RecvResultExt for BufResult<usize, (T, sockaddr_storage, socklen_t)> {
     }
 }
 
-pub use crate::driver::op::{Accept, RecvFromImpl, SendToImpl};
-
 #[cfg(target_os = "windows")]
 pub use crate::driver::op::ConnectNamedPipe;
+pub use crate::driver::op::{Accept, RecvFromImpl, SendToImpl};
 
 /// Read a file at specified position into specified buffer.
 #[derive(Debug)]

--- a/src/signal/unix.rs
+++ b/src/signal/unix.rs
@@ -1,11 +1,5 @@
 //! Unix-specific types for signal handling.
 
-use crate::{
-    driver::{Driver, Poller},
-    task::RUNTIME,
-};
-use once_cell::unsync::Lazy as LazyCell;
-use slab::Slab;
 use std::{
     cell::RefCell,
     collections::HashMap,
@@ -13,6 +7,14 @@ use std::{
     io,
     pin::Pin,
     task::{Context, Poll},
+};
+
+use once_cell::unsync::Lazy as LazyCell;
+use slab::Slab;
+
+use crate::{
+    driver::{Driver, Poller},
+    task::RUNTIME,
 };
 
 thread_local! {

--- a/src/signal/windows.rs
+++ b/src/signal/windows.rs
@@ -1,11 +1,5 @@
 //! Windows-specific types for signal handling.
 
-use crate::{
-    driver::{Driver, Poller},
-    task::RUNTIME,
-};
-use once_cell::sync::Lazy as LazyLock;
-use slab::Slab;
 use std::{
     collections::HashMap,
     future::Future,
@@ -14,12 +8,20 @@ use std::{
     sync::{Mutex, Once},
     task::{Context, Poll},
 };
+
+use once_cell::sync::Lazy as LazyLock;
+use slab::Slab;
 use windows_sys::Win32::{
     Foundation::BOOL,
     System::Console::{
         SetConsoleCtrlHandler, CTRL_BREAK_EVENT, CTRL_CLOSE_EVENT, CTRL_C_EVENT, CTRL_LOGOFF_EVENT,
         CTRL_SHUTDOWN_EVENT,
     },
+};
+
+use crate::{
+    driver::{Driver, Poller},
+    task::RUNTIME,
 };
 
 #[allow(clippy::type_complexity)]
@@ -111,27 +113,32 @@ impl Drop for CtrlEvent {
     }
 }
 
-/// Creates a new listener which receives "ctrl-break" notifications sent to the process.
+/// Creates a new listener which receives "ctrl-break" notifications sent to the
+/// process.
 pub fn ctrl_break() -> CtrlEvent {
     CtrlEvent::new(CTRL_BREAK_EVENT)
 }
 
-/// Creates a new listener which receives "ctrl-close" notifications sent to the process.
+/// Creates a new listener which receives "ctrl-close" notifications sent to the
+/// process.
 pub fn ctrl_close() -> CtrlEvent {
     CtrlEvent::new(CTRL_CLOSE_EVENT)
 }
 
-/// Creates a new listener which receives "ctrl-c" notifications sent to the process.
+/// Creates a new listener which receives "ctrl-c" notifications sent to the
+/// process.
 pub fn ctrl_c() -> CtrlEvent {
     CtrlEvent::new(CTRL_C_EVENT)
 }
 
-/// Creates a new listener which receives "ctrl-logoff" notifications sent to the process.
+/// Creates a new listener which receives "ctrl-logoff" notifications sent to
+/// the process.
 pub fn ctrl_logoff() -> CtrlEvent {
     CtrlEvent::new(CTRL_LOGOFF_EVENT)
 }
 
-/// Creates a new listener which receives "ctrl-shutdown" notifications sent to the process.
+/// Creates a new listener which receives "ctrl-shutdown" notifications sent to
+/// the process.
 pub fn ctrl_shutdown() -> CtrlEvent {
     CtrlEvent::new(CTRL_SHUTDOWN_EVENT)
 }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,5 +1,6 @@
 //! The runtime of compio.
-//! We don't expose the runtime struct because there could be only one runtime in each thread.
+//! We don't expose the runtime struct because there could be only one runtime
+//! in each thread.
 //!
 //! ```
 //! let ans = compio::task::block_on(async {
@@ -9,9 +10,10 @@
 //! assert_eq!(ans, 42);
 //! ```
 
+use std::future::Future;
+
 use async_task::Task;
 use once_cell::unsync::Lazy as LazyCell;
-use std::future::Future;
 
 mod runtime;
 use runtime::Runtime;

--- a/src/task/op.rs
+++ b/src/task/op.rs
@@ -1,5 +1,3 @@
-use crate::driver::OpCode;
-use slab::Slab;
 use std::{
     future::Future,
     io,
@@ -8,6 +6,10 @@ use std::{
     pin::Pin,
     task::{Context, Poll, Waker},
 };
+
+use slab::Slab;
+
+use crate::driver::OpCode;
 
 pub struct RawOp(*mut dyn OpCode);
 

--- a/src/task/runtime.rs
+++ b/src/task/runtime.rs
@@ -1,9 +1,3 @@
-use crate::{
-    driver::{Driver, Entry, OpCode, Poller, RawFd},
-    task::op::{OpFuture, OpRuntime},
-};
-use async_task::{Runnable, Task};
-use futures_util::future::Either;
 use std::{
     cell::RefCell,
     collections::VecDeque,
@@ -13,8 +7,15 @@ use std::{
     task::{Context, Poll},
 };
 
+use async_task::{Runnable, Task};
+use futures_util::future::Either;
+
 #[cfg(feature = "time")]
 use crate::task::time::{TimerFuture, TimerRuntime};
+use crate::{
+    driver::{Driver, Entry, OpCode, Poller, RawFd},
+    task::op::{OpFuture, OpRuntime},
+};
 
 pub(crate) struct Runtime {
     driver: Driver,

--- a/src/task/time.rs
+++ b/src/task/time.rs
@@ -1,4 +1,3 @@
-use slab::Slab;
 use std::{
     collections::BinaryHeap,
     future::Future,
@@ -6,6 +5,8 @@ use std::{
     task::{Context, Poll, Waker},
     time::{Duration, Instant},
 };
+
+use slab::Slab;
 
 #[derive(Debug)]
 struct TimerEntry {

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,6 +1,5 @@
 //! Utilities for tracking time.
 
-use futures_util::{select, FutureExt};
 use std::{
     error::Error,
     fmt::Display,
@@ -8,10 +7,12 @@ use std::{
     time::{Duration, Instant},
 };
 
+use futures_util::{select, FutureExt};
+
 /// Waits until `duration` has elapsed.
 ///
-/// Equivalent to [`sleep_until(Instant::now() + duration)`](sleep_until). An asynchronous
-/// analog to [`std::thread::sleep`].
+/// Equivalent to [`sleep_until(Instant::now() + duration)`](sleep_until). An
+/// asynchronous analog to [`std::thread::sleep`].
 ///
 /// To run something regularly on a schedule, see [`interval`].
 ///
@@ -20,8 +21,9 @@ use std::{
 /// Wait 100ms and print "100 ms have elapsed".
 ///
 /// ```
-/// use compio::time::sleep;
 /// use std::time::Duration;
+///
+/// use compio::time::sleep;
 ///
 /// compio::task::block_on(async {
 ///     sleep(Duration::from_millis(100)).await;
@@ -43,8 +45,9 @@ pub async fn sleep(duration: Duration) {
 /// Wait 100ms and print "100 ms have elapsed".
 ///
 /// ```
-/// use compio::time::sleep_until;
 /// use std::time::{Duration, Instant};
+///
+/// use compio::time::sleep_until;
 ///
 /// compio::task::block_on(async {
 ///     sleep_until(Instant::now() + Duration::from_millis(100)).await;
@@ -144,8 +147,9 @@ impl Interval {
 /// # Examples
 ///
 /// ```
-/// use compio::time::interval;
 /// use std::time::Duration;
+///
+/// use compio::time::interval;
 ///
 /// compio::task::block_on(async {
 ///     let mut interval = interval(Duration::from_millis(10));
@@ -170,8 +174,9 @@ impl Interval {
 /// seconds.
 ///
 /// ```no_run
-/// use compio::time::{interval, sleep};
 /// use std::time::Duration;
+///
+/// use compio::time::{interval, sleep};
 ///
 /// async fn task_that_takes_a_second() {
 ///     println!("hello");
@@ -206,8 +211,9 @@ pub fn interval(period: Duration) -> Interval {
 /// # Examples
 ///
 /// ```
-/// use compio::time::interval_at;
 /// use std::time::{Duration, Instant};
+///
+/// use compio::time::interval_at;
 ///
 /// compio::task::block_on(async {
 ///     let start = Instant::now() + Duration::from_millis(50);

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -1,5 +1,6 @@
-use compio::fs::File;
 use std::io::prelude::*;
+
+use compio::fs::File;
 use tempfile::NamedTempFile;
 
 const HELLO: &[u8] = b"hello world...";

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -28,7 +28,7 @@ fn send_to() {
         const MSG: &str = "foo bar baz";
 
         macro_rules! must_success {
-            ($r: expr, $expect_addr: expr) => {
+            ($r:expr, $expect_addr:expr) => {
                 let res = $r;
                 assert_eq!(res.0.unwrap().1, $expect_addr);
                 assert_eq!(res.1, MSG.as_bytes());


### PR DESCRIPTION
This PR adds my own `rustfmt.toml` and reformat all codes with it.