### PR TITLE
runtime dependencies are optional, once_cell is needed only for Rust …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,9 @@ time = ["runtime"]
 all = ["time", "signal"]
 
 lazy_cell = []
+once_cell_try = []
 read_buf = []
-nightly = ["read_buf", "lazy_cell"]
+nightly = ["read_buf", "lazy_cell", "once_cell_try"]
 stable = ["dep:once_cell"]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ default-target = "x86_64-pc-windows-msvc"
 targets = ["x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]
 
 [dependencies]
-async-task = "4"
+async-task = { version = "4", optional = true }
 bytes = { version = "1", optional = true }
 cfg-if = "1"
 crossbeam-queue = "0.3"
-futures-util = "0.3"
-once_cell = "1"
-slab = "0.4"
+futures-util = { version = "0.3", optional = true }
+once_cell = { version = "1", optional = true }
+slab = { version = "0.4", optional = true }
 socket2 = { version = "0.5", features = ["all"] }
 
 [dev-dependencies]
@@ -54,7 +54,9 @@ libc = "0.2"
 
 [features]
 default = ["runtime"]
-runtime = []
+# for Rust < 1.70
+once_cell = ["dep:once_cell"]
+runtime = ["dep:async-task", "dep:futures-util", "dep:slab"]
 signal = ["runtime"]
 time = ["runtime"]
 all = ["time", "signal"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,15 +54,15 @@ libc = "0.2"
 
 [features]
 default = ["runtime"]
-# for Rust < 1.70
-once_cell = ["dep:once_cell"]
 runtime = ["dep:async-task", "dep:futures-util", "dep:slab"]
 signal = ["runtime"]
 time = ["runtime"]
 all = ["time", "signal"]
 
+lazy_cell = []
 read_buf = []
-nightly = ["read_buf"]
+nightly = ["read_buf", "lazy_cell"]
+stable = ["dep:once_cell"]
 
 [[example]]
 name = "tick"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ io-uring = "0.6"
 libc = "0.2"
 
 [features]
-default = ["runtime"]
+default = ["runtime", "stable"]
 runtime = ["dep:async-task", "dep:futures-util", "dep:slab"]
 signal = ["runtime"]
 time = ["runtime"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ bytes = { version = "1", optional = true }
 cfg-if = "1"
 crossbeam-queue = { version = "0.3", optional = true }
 futures-util = { version = "0.3", optional = true }
-once_cell = { version = "1", optional = true }
+# may be excluded from linking if the unstable equivalent is used
+once_cell = "1"
 slab = { version = "0.4", optional = true }
 socket2 = { version = "0.5", features = ["all"] }
 
@@ -53,7 +54,7 @@ io-uring = "0.6"
 libc = "0.2"
 
 [features]
-default = ["runtime", "stable"]
+default = ["runtime"]
 runtime = ["dep:async-task", "dep:futures-util", "dep:slab"]
 sync-queue = ["dep:crossbeam-queue"]
 signal = ["runtime", "sync-queue"]
@@ -64,7 +65,6 @@ lazy_cell = []
 once_cell_try = []
 read_buf = []
 nightly = ["read_buf", "lazy_cell", "once_cell_try"]
-stable = ["dep:once_cell"]
 
 [[example]]
 name = "tick"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]
 async-task = { version = "4", optional = true }
 bytes = { version = "1", optional = true }
 cfg-if = "1"
-crossbeam-queue = "0.3"
+crossbeam-queue = { version = "0.3", optional = true }
 futures-util = { version = "0.3", optional = true }
 once_cell = { version = "1", optional = true }
 slab = { version = "0.4", optional = true }
@@ -55,7 +55,8 @@ libc = "0.2"
 [features]
 default = ["runtime", "stable"]
 runtime = ["dep:async-task", "dep:futures-util", "dep:slab"]
-signal = ["runtime"]
+sync-queue = ["dep:crossbeam-queue"]
+signal = ["runtime", "sync-queue"]
 time = ["runtime"]
 all = ["time", "signal"]
 
@@ -79,4 +80,8 @@ harness = false
 
 [[bench]]
 name = "named_pipe"
+harness = false
+
+[[bench]]
+name = "driver"
 harness = false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
           cargo +nightly test --features=all,nightly --target $(target) -Z doctest-xcompile
         displayName: TestNightly
       - script: |
-          cargo test --features all,stable --target $(target) -Z doctest-xcompile
+          cargo test --features all,stable --target $(target)
         displayName: TestStable
 
   - job: Test_Ubuntu

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ jobs:
           cargo +nightly test --features all,nightly
         displayName: TestNightly
       - script: |
-          cargo test --features all,stable --target $(target) -Z doctest-xcompile
+          cargo test --features all,stable
         displayName: TestStable
 
   - job: Doc

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,10 +20,10 @@ jobs:
       - script: |
           rustup toolchain install nightly
           rustup +nightly target install $(target)
-          cargo +nightly test --features=all,nightly --target $(target) -Z doctest-xcompile
+          cargo +nightly test --features=all,nightly --no-default-features --target $(target) -Z doctest-xcompile
         displayName: TestNightly
       - script: |
-          cargo test --features all,stable --target $(target)
+          cargo test --features all --target $(target)
         displayName: TestStable
 
   - job: Test_Ubuntu
@@ -39,10 +39,10 @@ jobs:
     steps:
       - script: |
           rustup toolchain install nightly
-          cargo +nightly test --features all,nightly
+          cargo +nightly test --features all,nightly --no-default-features
         displayName: TestNightly
       - script: |
-          cargo test --features all,stable
+          cargo test --features all
         displayName: TestStable
 
   - job: Doc
@@ -58,5 +58,5 @@ jobs:
     steps:
       - script: |
           rustup toolchain install nightly
-          cargo +nightly doc --features all,nightly --no-deps
+          cargo +nightly doc --features all --no-deps
         displayName: Build docs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,53 +4,59 @@ trigger:
       - master
 
 jobs:
-- job: Test_Windows
-  strategy:
-    matrix:
-      x86:
-        target: i686-pc-windows-msvc
-      x64:
-        target: x86_64-pc-windows-msvc
-      x64-gnu:
-        target: x86_64-pc-windows-gnu
-  pool:
-    vmImage: windows-latest
+  - job: Test_Windows
+    strategy:
+      matrix:
+        x86:
+          target: i686-pc-windows-msvc
+        x64:
+          target: x86_64-pc-windows-msvc
+        x64-gnu:
+          target: x86_64-pc-windows-gnu
+    pool:
+      vmImage: windows-latest
 
-  steps:
-  - script: |
-      rustup toolchain install nightly
-      rustup +nightly target install $(target)
-      cargo +nightly test --all-features --target $(target) -Z doctest-xcompile
-    displayName: Test
+    steps:
+      - script: |
+          rustup toolchain install nightly
+          rustup +nightly target install $(target)
+          cargo +nightly test --features=all,nightly --target $(target) -Z doctest-xcompile
+        displayName: TestNightly
+      - script: |
+          cargo test --features all,stable --target $(target) -Z doctest-xcompile
+        displayName: TestStable
 
-- job: Test_Ubuntu
-  strategy:
-    matrix:
-      focal:
-        image: ubuntu-20.04
-      jammy:
-        image: ubuntu-22.04
-  pool:
-    vmImage: $(image)
+  - job: Test_Ubuntu
+    strategy:
+      matrix:
+        focal:
+          image: ubuntu-20.04
+        jammy:
+          image: ubuntu-22.04
+    pool:
+      vmImage: $(image)
 
-  steps:
-  - script: |
-      rustup toolchain install nightly
-      cargo +nightly test --all-features
-    displayName: Test
+    steps:
+      - script: |
+          rustup toolchain install nightly
+          cargo +nightly test --features all,nightly
+        displayName: TestNightly
+      - script: |
+          cargo test --features all,stable --target $(target) -Z doctest-xcompile
+        displayName: TestStable
 
-- job: Doc
-  strategy:
-    matrix:
-      windows:
-        image: windows-latest
-      linux:
-        image: ubuntu-latest
-  pool:
-    vmImage: $(image)
+  - job: Doc
+    strategy:
+      matrix:
+        windows:
+          image: windows-latest
+        linux:
+          image: ubuntu-latest
+    pool:
+      vmImage: $(image)
 
-  steps:
-  - script: |
-      rustup toolchain install nightly
-      cargo +nightly doc --all-features --no-deps
-    displayName: Build docs
+    steps:
+      - script: |
+          rustup toolchain install nightly
+          cargo +nightly doc --features all,nightly --no-deps
+        displayName: Build docs

--- a/benches/driver.rs
+++ b/benches/driver.rs
@@ -1,0 +1,21 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+criterion_group!(driver, create_and_post_1024);
+criterion_main!(driver);
+
+fn create_and_post_1024(c: &mut Criterion) {
+    let mut group = c.benchmark_group("create_and_post");
+
+    group.bench_function("create_and_post", |b| {
+        b.iter(|| {
+            use compio::driver::{Driver, Poller};
+
+            let driver = Driver::new().expect("created");
+            for i in 0..1024_usize {
+                let _ = driver.post(i, 0).expect("succeeded");
+            }
+        })
+    });
+
+    group.finish();
+}

--- a/src/driver/iocp/mod.rs
+++ b/src/driver/iocp/mod.rs
@@ -27,8 +27,7 @@ use windows_sys::Win32::{
     },
 };
 
-use super::queue::Queue;
-use crate::driver::{Entry, Poller};
+use crate::driver::{queue::Queue, Entry, Poller};
 
 pub(crate) mod fs;
 pub(crate) mod net;

--- a/src/driver/iocp/mod.rs
+++ b/src/driver/iocp/mod.rs
@@ -11,7 +11,6 @@ use std::{
     time::Duration,
 };
 
-use crossbeam_queue::SegQueue;
 use windows_sys::Win32::{
     Foundation::{
         RtlNtStatusToDosError, FACILITY_NTWIN32, INVALID_HANDLE_VALUE, NTSTATUS, STATUS_PENDING,
@@ -28,6 +27,7 @@ use windows_sys::Win32::{
     },
 };
 
+use super::queue::Queue;
 use crate::driver::{Entry, Poller};
 
 pub(crate) mod fs;
@@ -81,13 +81,15 @@ pub trait OpCode {
 /// Low-level driver of IOCP.
 pub struct Driver {
     port: OwnedHandle,
-    operations: SegQueue<(*mut dyn OpCode, Overlapped)>,
+    operations: Queue<(*mut dyn OpCode, Overlapped)>,
 }
 
 unsafe impl Send for Driver {}
 unsafe impl Sync for Driver {}
 
 impl Driver {
+    const DEFAULT_CAPACITY: usize = 1024;
+
     /// Create a new IOCP.
     pub fn new() -> io::Result<Self> {
         let port = unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, 0, 0, 0) };
@@ -95,7 +97,7 @@ impl Driver {
             .map_err(|_| io::Error::last_os_error())?;
         Ok(Self {
             port,
-            operations: SegQueue::default(),
+            operations: Queue::with_capacity(Self::DEFAULT_CAPACITY),
         })
     }
 }

--- a/src/driver/iocp/op.rs
+++ b/src/driver/iocp/op.rs
@@ -1,13 +1,10 @@
-#[cfg(not(feature = "once_cell"))]
-use std::sync::OnceLock;
 use std::{
     io,
     ptr::{null, null_mut},
+    sync::OnceLock,
     task::Poll,
 };
 
-#[cfg(feature = "once_cell")]
-use once_cell::sync::OnceCell as OnceLock;
 use socket2::SockAddr;
 use windows_sys::{
     core::GUID,

--- a/src/driver/iocp/op.rs
+++ b/src/driver/iocp/op.rs
@@ -1,10 +1,13 @@
+#[cfg(feature = "once_cell_try")]
+use std::sync::OnceLock;
 use std::{
     io,
     ptr::{null, null_mut},
-    sync::OnceLock,
     task::Poll,
 };
 
+#[cfg(not(feature = "once_cell_try"))]
+use once_cell::sync::OnceCell as OnceLock;
 use socket2::SockAddr;
 use windows_sys::{
     core::GUID,

--- a/src/driver/iocp/op.rs
+++ b/src/driver/iocp/op.rs
@@ -1,9 +1,12 @@
+#[cfg(not(feature = "once_cell"))]
+use std::sync::OnceLock;
 use std::{
     io,
     ptr::{null, null_mut},
     task::Poll,
 };
 
+#[cfg(feature = "once_cell")]
 use once_cell::sync::OnceCell as OnceLock;
 use socket2::SockAddr;
 use windows_sys::{

--- a/src/driver/iour/mod.rs
+++ b/src/driver/iour/mod.rs
@@ -9,8 +9,7 @@ use io_uring::{
 };
 pub(crate) use libc::{sockaddr_storage, socklen_t};
 
-use super::queue::Queue;
-use crate::driver::{Entry, Poller};
+use crate::driver::{queue::Queue, Entry, Poller};
 
 pub(crate) mod fs;
 pub(crate) mod net;

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -3,6 +3,8 @@
 
 use std::{io, mem::MaybeUninit, time::Duration};
 
+mod queue;
+
 cfg_if::cfg_if! {
     if #[cfg(target_os = "windows")] {
         mod iocp;

--- a/src/driver/queue.rs
+++ b/src/driver/queue.rs
@@ -1,0 +1,71 @@
+#[cfg(not(feature = "sync-queue"))]
+use std::{cell::UnsafeCell, collections::VecDeque};
+
+#[cfg(feature = "sync-queue")]
+use crossbeam_queue::SegQueue;
+
+#[cfg(feature = "sync-queue")]
+#[repr(transparent)]
+pub(super) struct Queue<T>(SegQueue<T>);
+
+#[cfg(feature = "sync-queue")]
+impl<T> Queue<T> {
+    pub fn with_capacity(_capacity: usize) -> Self {
+        Self(SegQueue::new())
+    }
+
+    pub fn push(&self, value: T) {
+        self.0.push(value);
+    }
+
+    pub fn pop(&self) -> Option<T> {
+        self.0.pop()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+#[cfg(not(feature = "sync-queue"))]
+#[repr(transparent)]
+pub(super) struct Queue<T>(UnsafeCell<VecDeque<T>>);
+
+#[cfg(not(feature = "sync-queue"))]
+impl<T> Queue<T> {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(UnsafeCell::new(VecDeque::with_capacity(capacity)))
+    }
+
+    pub fn push(&self, value: T) {
+        unsafe {
+            // SAFETY: we expect that only single thread uses the queue
+            (&mut *self.0.get()).push_back(value);
+        }
+    }
+
+    pub fn pop(&self) -> Option<T> {
+        unsafe {
+            // SAFETY: we expect that only single thread uses the queue
+            (&mut *self.0.get()).pop_front()
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        unsafe {
+            // SAFETY: we expect that only single thread uses the queue
+            (&*self.0.get()).len()
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        unsafe {
+            // SAFETY: we expect that only single thread uses the queue
+            (&*self.0.get()).is_empty()
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 //!
 #![doc = include_str!("../README.md")]
 #![cfg_attr(feature = "read_buf", feature(read_buf))]
-#![cfg_attr(feature = "nightly", feature(lazy_cell))]
+#![cfg_attr(feature = "lazy_cell", feature(lazy_cell))]
+#![cfg_attr(feature = "once_cell_try", feature(once_cell_try))]
 #![warn(missing_docs)]
 
 pub mod buf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //!
 #![doc = include_str!("../README.md")]
 #![cfg_attr(feature = "read_buf", feature(read_buf))]
+#![cfg_attr(feature = "nightly", feature(lazy_cell))]
 #![warn(missing_docs)]
 
 pub mod buf;

--- a/src/signal/unix.rs
+++ b/src/signal/unix.rs
@@ -1,5 +1,7 @@
 //! Unix-specific types for signal handling.
 
+#[cfg(feature = "lazy_cell")]
+use std::sync::LazyCell;
 use std::{
     cell::RefCell,
     collections::HashMap,
@@ -9,6 +11,7 @@ use std::{
     task::{Context, Poll},
 };
 
+#[cfg(not(feature = "lazy_cell"))]
 use once_cell::unsync::Lazy as LazyCell;
 use slab::Slab;
 

--- a/src/signal/unix.rs
+++ b/src/signal/unix.rs
@@ -1,7 +1,7 @@
 //! Unix-specific types for signal handling.
 
 #[cfg(feature = "lazy_cell")]
-use std::sync::LazyCell;
+use std::cell::LazyCell;
 use std::{
     cell::RefCell,
     collections::HashMap,

--- a/src/signal/windows.rs
+++ b/src/signal/windows.rs
@@ -1,5 +1,7 @@
 //! Windows-specific types for signal handling.
 
+#[cfg(not(feature = "once_cell"))]
+use std::sync::OnceLock;
 use std::{
     collections::HashMap,
     future::Future,
@@ -9,6 +11,7 @@ use std::{
     task::{Context, Poll},
 };
 
+#[cfg(feature = "once_cell")]
 use once_cell::sync::Lazy as LazyLock;
 use slab::Slab;
 use windows_sys::Win32::{

--- a/src/signal/windows.rs
+++ b/src/signal/windows.rs
@@ -1,7 +1,7 @@
 //! Windows-specific types for signal handling.
 
-#[cfg(not(feature = "once_cell"))]
-use std::sync::OnceLock;
+#[cfg(feature = "lazy_cell")]
+use std::sync::LazyLock;
 use std::{
     collections::HashMap,
     future::Future,
@@ -11,7 +11,7 @@ use std::{
     task::{Context, Poll},
 };
 
-#[cfg(feature = "once_cell")]
+#[cfg(not(feature = "lazy_cell"))]
 use once_cell::sync::Lazy as LazyLock;
 use slab::Slab;
 use windows_sys::Win32::{

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -10,9 +10,12 @@
 //! assert_eq!(ans, 42);
 //! ```
 
+#[cfg(not(feature = "once_cell"))]
+use std::cell::OnceCell as LazyCell;
 use std::future::Future;
 
 use async_task::Task;
+#[cfg(feature = "once_cell")]
 use once_cell::unsync::Lazy as LazyCell;
 
 mod runtime;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -10,12 +10,12 @@
 //! assert_eq!(ans, 42);
 //! ```
 
-#[cfg(not(feature = "once_cell"))]
-use std::cell::OnceCell as LazyCell;
+#[cfg(feature = "lazy_cell")]
+use std::cell::LazyCell;
 use std::future::Future;
 
 use async_task::Task;
-#[cfg(feature = "once_cell")]
+#[cfg(not(feature = "lazy_cell"))]
 use once_cell::unsync::Lazy as LazyCell;
 
 mod runtime;


### PR DESCRIPTION
At the moment I'm interested in the driver code to build custom runtime, potentially not async.

So I made runtime-related dependencies optional. Besides I moved `once_cell` dependency to non default "once_cell" feature. For Rust version >= 1.70 OnceCell/OnceLock is part of `std`.