### PR TITLE
[DRAFT] initial interface for registered file descriptors

### DIFF
--- a/examples/driver.rs
+++ b/examples/driver.rs
@@ -6,9 +6,9 @@ use compio::{
 fn main() {
     let driver = Driver::new().unwrap();
     let file = compio::fs::File::open("Cargo.toml").unwrap();
-    driver.attach(file.as_raw_fd()).unwrap();
+    let registered_fd = driver.attach(file.as_raw_fd()).unwrap();
 
-    let mut op = compio::op::ReadAt::new(file.as_raw_fd(), 0, Vec::with_capacity(4096));
+    let mut op = compio::op::ReadAt::new(registered_fd, 0, Vec::with_capacity(4096));
     unsafe { driver.push(&mut op, 0) }.unwrap();
 
     let entry = driver.poll_one(None).unwrap();

--- a/src/driver/iocp/mod.rs
+++ b/src/driver/iocp/mod.rs
@@ -118,6 +118,7 @@ pub trait OpCode {
 pub struct Driver {
     port: OwnedHandle,
     operations: Queue<(*mut dyn OpCode, Overlapped)>,
+    attached_files: UnsafeCell<Vec<RawFd>>,
 }
 
 unsafe impl Send for Driver {}
@@ -301,6 +302,18 @@ impl Poller for Driver {
             entry.write(Entry::new(overlapped.user_data, res));
         }
         Ok(iocp_len)
+    }
+}
+
+impl DriverRegisteredFileDescriptors for Driver {
+    // reference to registered files slice
+    fn registered_files(&self) -> &[RawFd] {
+        unsafe { &*self.attached_files.get() }
+    }
+
+    // mutable reference to registered files slice
+    fn registered_files_mut(&self) -> &mut [RawFd] {
+        unsafe { &mut *self.attached_files.get() }
     }
 }
 

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,7 +1,11 @@
 //! The platform-specified driver.
 //! Some types differ by compilation target.
 
+mod registered_fd;
+
 use std::{io, mem::MaybeUninit, time::Duration};
+
+pub use registered_fd::{RegisteredFd, RegisteredFdUpdate, RegisteredFileDescriptors};
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "windows")] {

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -96,7 +96,7 @@ pub trait Poller {
     /// ## Platform specific
     /// * IOCP: it will be attached to the IOCP completion port.
     /// * io-uring: it will do nothing and return `Ok(())`
-    fn attach(&self, fd: RawFd) -> io::Result<()>;
+    fn attach(&self, fd: RawFd) -> io::Result<RegisteredFd>;
 
     /// Push an operation with user-defined data.
     /// The data could be retrived from [`Entry`] when polling.

--- a/src/driver/registered_fd.rs
+++ b/src/driver/registered_fd.rs
@@ -1,0 +1,112 @@
+//! Registered file descriptor interface with default platform independent
+//! implementation
+
+/// Registered file descriptor is valid only for owning thread
+///
+///
+/// It's not `Send` and not `Sync`
+use std::{
+    io,
+    marker::PhantomData,
+    mem::{transmute, MaybeUninit},
+    os::fd::{IntoRawFd, OwnedFd, RawFd},
+};
+
+use super::Poller;
+use crate::buf::Slice;
+
+/// Registered fd is owned by a single thread
+///
+/// Concurrent operations could copy it.
+/// If previously registered fd has become unregistered subsequent registered fd
+/// usage could result in IO error
+#[derive(Debug, Clone, Copy)]
+pub struct RegisteredFd {
+    // 31 bit fd idx
+    fd_idx: u32,
+    _nor_send_nor_sync: PhantomData<*const ()>,
+}
+
+impl RegisteredFd {
+    // not allocated slot for registered file descriptors
+    // we use this value instead of -1 because we work with unsigned offset values
+    // the value is outside of the i32 range used by Linux kernel
+    const NOT_ALLOCATED: Self = Self::new(u32::MAX);
+
+    // private
+    const fn new(fd_idx: RawFd) -> Self {
+        Self {
+            fd_idx,
+            _nor_send_nor_sync: PhantomData,
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct RegisteredFdUpdate(RawFd);
+
+impl RegisteredFdUpdate {
+    const SKIP_UPDATE: RegisteredFdUpdate = -2;
+    const UNREGISTER: RegisteredFdUpdate = -1;
+
+    pub const fn unregister() -> Self {
+        Self::UNREGISTER
+    }
+
+    pub const fn skip() -> Self {
+        Self::SKIP_UPDATE
+    }
+
+    pub const fn replace(replacement: RegisteredFd) -> Self {
+        Self(replacement.into_raw_fd())
+    }
+}
+
+/// Public registration API
+pub trait RegisteredFileDescriptors: Poller {
+    /// Allocate boxed array of raw fds, initialized with -1 (not allocated)
+    /// value
+    ///
+    /// Use cases:
+    /// * Runtime registers empty descriptor storage
+    /// * Runtime could preallocate descriptor storage and let user to
+    ///   initialize it
+    /// incrementally
+    /// * drivers for platforms that don't support registered
+    /// files could emulate it on top of this storage
+    fn allocate_file_descriptors<const N: usize>(&mut self) -> Box<[RawFd; N]> {
+        // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
+        // safe because the type we are claiming to have initialized here is a
+        // bunch of `MaybeUninit`s, which do not require initialization.
+        let mut data: Box<[MaybeUninit<RawFd>; N]> = unsafe { MaybeUninit::uninit().assume_init() };
+
+        // Dropping a `MaybeUninit` does nothing, so if there is a panic during this
+        // loop, we have a memory leak, but there is no memory safety issue.
+        for elem in &mut data[..] {
+            elem.write(RegisteredFd::NOT_ALLOCATED);
+        }
+
+        // SAFETY: Everything is initialized. Transmute the array to the
+        // initialized type.
+        unsafe { transmute::<_, Box<[RawFd; N]>>(data) }
+    }
+
+    /// Register owned files synchronously
+    ///
+    /// Userspace descriptors will be closed after registration unless driver
+    /// emulates registration
+    fn register_files(fds: IntoIterator<Item = OwnedFd>) -> io::Result<()> {}
+    /// Register files synchronously
+    ///
+    /// On Linux will block until all inflight operations will finish
+    fn register_raw_files(fds: &[RawFd]) -> io::Result<()> {}
+    /// Replace registered files synchronously
+    ///
+    /// On Linux will block until all inflight operations will finish
+    fn register_files_update(offset: u32, fds: &[RegisteredFdUpdate]) {}
+    /// Replace registered files asynchronously
+    ///
+    /// The owned fds slice with the underlying allocation will be returned by a
+    /// runtime method when operation is completed
+    fn push_register_files_update(offset: u32, fds: Slice<Box<[RegisteredFdUpdate]>>) {}
+}

--- a/src/driver/registered_fd.rs
+++ b/src/driver/registered_fd.rs
@@ -95,7 +95,12 @@ pub trait RegisteredFileDescriptors: Poller {
     ///
     /// Userspace descriptors will be closed after registration unless driver
     /// emulates registration
-    fn register_files(fds: IntoIterator<Item = OwnedFd>) -> io::Result<()> {}
+    fn register_files<const N: usize>(fds: [OwnedFd; N]) -> io::Result<()> {}
+    /// Register owned files synchronously. Boxed slice variant
+    ///
+    /// Userspace descriptors will be closed after registration unless driver
+    /// emulates registration
+    fn register_boxed_files(fds: Box<[OwnedFd]>) -> io::Result<()> {}
     /// Register files synchronously
     ///
     /// On Linux will block until all inflight operations will finish

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ macro_rules! impl_raw_fd {
             unsafe fn from_raw_fd(fd: crate::driver::RawFd) -> Self {
                 Self {
                     $inner: crate::driver::FromRawFd::from_raw_fd(fd),
+                    registered_fd: crate::driver::RegisteredFd::UNREGISTERED,
                 }
             }
         }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,8 +1,11 @@
 use socket2::{Protocol, Type};
 
-use crate::net::{Socket, *};
 #[cfg(feature = "runtime")]
 use crate::{buf::*, *};
+use crate::{
+    driver::RegisteredFd,
+    net::{Socket, *},
+};
 
 /// A UDP socket.
 ///
@@ -91,6 +94,7 @@ use crate::{buf::*, *};
 /// ```
 pub struct UdpSocket {
     inner: Socket,
+    registered_fd: RegisteredFd,
 }
 
 impl UdpSocket {
@@ -99,6 +103,7 @@ impl UdpSocket {
         super::each_addr(addr, |addr| {
             Ok(Self {
                 inner: Socket::bind(&addr, Type::DGRAM, Some(Protocol::UDP))?,
+                registered_fd: RegisteredFd::UNREGISTERED,
             })
         })
     }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -12,7 +12,7 @@
 
 #[cfg(feature = "lazy_cell")]
 use std::cell::LazyCell;
-use std::future::Future;
+use std::{future::Future, io};
 
 use async_task::Task;
 #[cfg(not(feature = "lazy_cell"))]
@@ -69,4 +69,9 @@ pub fn block_on<F: Future>(future: F) -> F::Output {
 /// ```
 pub fn spawn<F: Future + 'static>(future: F) -> Task<F::Output> {
     RUNTIME.with(|runtime| runtime.spawn(future))
+}
+
+/// Register file descriptors attached to the runtime
+pub fn register_attached_files() -> io::Result<()> {
+    RUNTIME.with(|runtime| runtime.register_attached_files())
 }

--- a/src/task/runtime.rs
+++ b/src/task/runtime.rs
@@ -13,7 +13,7 @@ use futures_util::future::Either;
 #[cfg(feature = "time")]
 use crate::task::time::{TimerFuture, TimerRuntime};
 use crate::{
-    driver::{Driver, Entry, OpCode, Poller, RawFd},
+    driver::{Driver, Entry, OpCode, Poller, RawFd, RegisteredFd, RegisteredFileDescriptors},
     task::op::{OpFuture, OpRuntime},
     Key,
 };
@@ -76,8 +76,12 @@ impl Runtime {
         task
     }
 
-    pub fn attach(&self, fd: RawFd) -> io::Result<()> {
+    pub fn attach(&self, fd: RawFd) -> io::Result<RegisteredFd> {
         self.driver.attach(fd)
+    }
+
+    pub fn register_attached_files(&self) -> io::Result<()> {
+        self.driver.register_attached_files()
     }
 
     pub fn submit<T: OpCode + 'static>(

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -1,6 +1,6 @@
 use std::io::prelude::*;
 
-use compio::fs::File;
+use compio::{driver::AsRawFd, fs::File, task::register_attached_files};
 use tempfile::NamedTempFile;
 
 const HELLO: &[u8] = b"hello world...";
@@ -21,6 +21,7 @@ fn basic_read() {
         tempfile.write_all(HELLO).unwrap();
 
         let file = File::open(tempfile.path()).unwrap();
+        register_attached_files().unwrap();
         read_hello(&file).await;
     });
 }
@@ -31,6 +32,8 @@ fn basic_write() {
         let tempfile = tempfile();
 
         let file = File::create(tempfile.path()).unwrap();
+
+        register_attached_files().unwrap();
 
         file.write_all_at(HELLO, 0).await.0.unwrap();
         file.sync_all().await.unwrap();
@@ -48,6 +51,8 @@ fn cancel_read() {
 
         let file = File::open(tempfile.path()).unwrap();
 
+        register_attached_files().unwrap();
+
         // Poll the future once, then cancel it
         poll_once(async { read_hello(&file).await }).await;
 
@@ -63,6 +68,7 @@ fn drop_open() {
 
         // Do something else
         let file = File::create(tempfile.path()).unwrap();
+        register_attached_files().unwrap();
 
         file.write_all_at(HELLO, 0).await.0.unwrap();
 

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1,4 +1,4 @@
-use compio::{buf::*, fs::File};
+use compio::{buf::*, fs::File, task::register_attached_files};
 use tempfile::NamedTempFile;
 
 // Ignore this test because we need to keep the buffer until
@@ -47,6 +47,7 @@ fn drop_on_complete() {
 
     let file = compio::task::block_on(async {
         let file = File::open(tempfile.path()).unwrap();
+        register_attached_files().unwrap();
         file.read_at(
             MyBuf {
                 data: Vec::with_capacity(64 * 1024),
@@ -71,6 +72,7 @@ fn too_many_submissions() {
 
     compio::task::block_on(async {
         let file = File::create(tempfile.path()).unwrap();
+        register_attached_files().unwrap();
         for _ in 0..600 {
             poll_once(async {
                 file.write_at("hello world", 0).await.0.unwrap();

--- a/tests/tcp_accept.rs
+++ b/tests/tcp_accept.rs
@@ -1,8 +1,12 @@
-use compio::net::{TcpListener, TcpStream, ToSockAddrs};
+use compio::{
+    net::{TcpListener, TcpStream, ToSockAddrs},
+    task::register_attached_files,
+};
 
 async fn test_impl(addr: impl ToSockAddrs) {
     let listener = TcpListener::bind(addr).unwrap();
     let addr = listener.local_addr().unwrap();
+    register_attached_files().unwrap();
     let (tx, rx) = futures_channel::oneshot::channel();
     compio::task::spawn(async move {
         let (socket, _) = listener.accept().await.unwrap();

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -1,4 +1,4 @@
-use compio::net::UdpSocket;
+use compio::{net::UdpSocket, task::register_attached_files};
 
 #[test]
 fn connect() {
@@ -10,6 +10,8 @@ fn connect() {
 
         let active = UdpSocket::bind("127.0.0.1:0").unwrap();
         let active_addr = active.local_addr().unwrap();
+
+        register_attached_files().unwrap();
 
         active.connect(&passive_addr).unwrap();
         active.send(MSG).await.0.unwrap();
@@ -49,6 +51,8 @@ fn send_to() {
 
         let active = UdpSocket::bind("127.0.0.1:0").unwrap();
         let active_addr = active.local_addr().unwrap();
+
+        register_attached_files().unwrap();
 
         active.send_to(MSG, &passive01_addr).await.0.unwrap();
         active.send_to(MSG, &passive1_addr).await.0.unwrap();


### PR DESCRIPTION
Registered thread local file descriptors allow kernel or driver to manage actual file descriptors and decrease descriptor refcounting overhead