### PR TITLE
Lazy attach

### DIFF
--- a/src/attacher.rs
+++ b/src/attacher.rs
@@ -1,0 +1,27 @@
+use std::io;
+#[cfg(feature = "once_cell_try")]
+use std::sync::OnceLock;
+
+#[cfg(not(feature = "once_cell_try"))]
+use once_cell::sync::OnceCell as OnceLock;
+
+use crate::{driver::AsRawFd, task::RUNTIME};
+
+#[derive(Debug)]
+pub struct Attacher {
+    once: OnceLock<()>,
+}
+
+impl Attacher {
+    pub const fn new() -> Self {
+        Self {
+            once: OnceLock::new(),
+        }
+    }
+
+    pub fn attach(&self, source: &impl AsRawFd) -> io::Result<()> {
+        self.once
+            .get_or_try_init(|| RUNTIME.with(|runtime| runtime.attach(source.as_raw_fd())))?;
+        Ok(())
+    }
+}

--- a/src/attacher.rs
+++ b/src/attacher.rs
@@ -1,21 +1,30 @@
-use std::io;
 #[cfg(feature = "once_cell_try")]
 use std::sync::OnceLock;
+use std::{io, marker::PhantomData};
 
 #[cfg(not(feature = "once_cell_try"))]
 use once_cell::sync::OnceCell as OnceLock;
 
 use crate::{driver::AsRawFd, task::RUNTIME};
 
+/// Attach a handle to the driver of current thread.
+///
+/// A handle can and only can attach once to one driver. However, the handle
+/// itself is Send & Sync. We mark it !Send & !Sync to warn users, making them
+/// ensure that they are using it in the correct thread.
 #[derive(Debug, Clone)]
 pub struct Attacher {
+    // Make it thread safe.
     once: OnceLock<()>,
+    // Make it !Send & !Sync.
+    _p: PhantomData<*mut ()>,
 }
 
 impl Attacher {
     pub const fn new() -> Self {
         Self {
             once: OnceLock::new(),
+            _p: PhantomData,
         }
     }
 

--- a/src/attacher.rs
+++ b/src/attacher.rs
@@ -7,7 +7,7 @@ use once_cell::sync::OnceCell as OnceLock;
 
 use crate::{driver::AsRawFd, task::RUNTIME};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Attacher {
     once: OnceLock<()>,
 }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -75,8 +75,10 @@ pub trait Poller {
     /// Attach an fd to the driver.
     ///
     /// ## Platform specific
-    /// * IOCP: it will be attached to the IOCP completion port. An fd could
-    ///   only be attached to one driver, and could only be attached once.
+    /// * IOCP: it will be attached to the completion port. An fd could only be
+    ///   attached to one driver, and could only be attached once, even if you
+    ///   `try_clone` it. It will cause unexpected result to attach the handle
+    ///   with one driver and push an op to another driver.
     /// * io-uring/mio: it will do nothing and return `Ok(())`
     fn attach(&mut self, fd: RawFd) -> io::Result<()>;
 

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -75,7 +75,8 @@ pub trait Poller {
     /// Attach an fd to the driver.
     ///
     /// ## Platform specific
-    /// * IOCP: it will be attached to the IOCP completion port.
+    /// * IOCP: it will be attached to the IOCP completion port. An fd could
+    ///   only be attached to one driver, and could only be attached once.
     /// * io-uring/mio: it will do nothing and return `Ok(())`
     fn attach(&mut self, fd: RawFd) -> io::Result<()>;
 

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -81,6 +81,17 @@ impl File {
         self.attacher.attach(self)
     }
 
+    /// Creates a new `File` instance that shares the same underlying file
+    /// handle as the existing `File` instance. This is useful when sending the
+    /// file handle to another thread.
+    pub fn try_clone(&self) -> io::Result<Self> {
+        Ok(Self {
+            inner: self.inner.try_clone()?,
+            #[cfg(feature = "runtime")]
+            attacher: Attacher::new(),
+        })
+    }
+
     /// Queries metadata about the underlying file.
     pub fn metadata(&self) -> io::Result<Metadata> {
         self.inner.metadata()

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -82,8 +82,9 @@ impl File {
     }
 
     /// Creates a new `File` instance that shares the same underlying file
-    /// handle as the existing `File` instance. This is useful when sending the
-    /// file handle to another thread.
+    /// handle as the existing `File` instance.
+    ///
+    /// It does not clear the attach state.
     pub fn try_clone(&self) -> io::Result<Self> {
         Ok(Self {
             inner: self.inner.try_clone()?,

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -88,7 +88,7 @@ impl File {
         Ok(Self {
             inner: self.inner.try_clone()?,
             #[cfg(feature = "runtime")]
-            attacher: Attacher::new(),
+            attacher: self.attacher.clone(),
         })
     }
 

--- a/src/named_pipe.rs
+++ b/src/named_pipe.rs
@@ -107,6 +107,13 @@ impl NamedPipeServer {
         Ok(unsafe { Self::from_raw_fd(handle.into_raw_handle()) })
     }
 
+    /// Creates a new independently owned handle to the underlying file handle.
+    pub fn try_clone(&self) -> io::Result<Self> {
+        Ok(Self {
+            handle: self.handle.try_clone()?,
+        })
+    }
+
     /// Retrieves information about the named pipe the server is associated
     /// with.
     ///
@@ -280,6 +287,13 @@ pub struct NamedPipeClient {
 impl NamedPipeClient {
     pub(crate) fn from_handle(handle: OwnedHandle) -> io::Result<Self> {
         Ok(unsafe { Self::from_raw_fd(handle.into_raw_handle()) })
+    }
+
+    /// Creates a new independently owned handle to the underlying file handle.
+    pub fn try_clone(&self) -> io::Result<Self> {
+        Ok(Self {
+            handle: self.handle.try_clone()?,
+        })
     }
 
     /// Retrieves information about the named pipe the client is associated

--- a/src/named_pipe.rs
+++ b/src/named_pipe.rs
@@ -104,8 +104,6 @@ pub struct NamedPipeServer {
 
 impl NamedPipeServer {
     pub(crate) fn from_handle(handle: OwnedHandle) -> io::Result<Self> {
-        #[cfg(feature = "runtime")]
-        RUNTIME.with(|runtime| runtime.attach(handle.as_raw_handle() as _))?;
         Ok(unsafe { Self::from_raw_fd(handle.into_raw_handle()) })
     }
 
@@ -167,6 +165,7 @@ impl NamedPipeServer {
     /// ```
     #[cfg(feature = "runtime")]
     pub async fn connect(&self) -> io::Result<()> {
+        self.handle.attach()?;
         let op = ConnectNamedPipe::new(self.as_raw_fd());
         RUNTIME.with(|runtime| runtime.submit(op)).await.0?;
         Ok(())
@@ -280,8 +279,6 @@ pub struct NamedPipeClient {
 
 impl NamedPipeClient {
     pub(crate) fn from_handle(handle: OwnedHandle) -> io::Result<Self> {
-        #[cfg(feature = "runtime")]
-        RUNTIME.with(|runtime| runtime.attach(handle.as_raw_handle() as _))?;
         Ok(unsafe { Self::from_raw_fd(handle.into_raw_handle()) })
     }
 

--- a/src/named_pipe.rs
+++ b/src/named_pipe.rs
@@ -108,6 +108,8 @@ impl NamedPipeServer {
     }
 
     /// Creates a new independently owned handle to the underlying file handle.
+    ///
+    /// It does not clear the attach state.
     pub fn try_clone(&self) -> io::Result<Self> {
         Ok(Self {
             handle: self.handle.try_clone()?,
@@ -290,6 +292,8 @@ impl NamedPipeClient {
     }
 
     /// Creates a new independently owned handle to the underlying file handle.
+    ///
+    /// It does not clear the attach state.
     pub fn try_clone(&self) -> io::Result<Self> {
         Ok(Self {
             handle: self.handle.try_clone()?,

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -37,7 +37,11 @@ impl Socket {
     }
 
     pub fn try_clone(&self) -> io::Result<Self> {
-        Ok(Self::from_socket2(self.socket.try_clone()?))
+        Ok(Self {
+            socket: self.socket.try_clone()?,
+            #[cfg(feature = "runtime")]
+            attacher: self.attacher.clone(),
+        })
     }
 
     pub fn peer_addr(&self) -> io::Result<SockAddr> {

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -63,6 +63,13 @@ impl TcpListener {
         })
     }
 
+    /// Creates a new independently owned handle to the underlying socket.
+    pub fn try_clone(&self) -> io::Result<Self> {
+        Ok(Self {
+            inner: self.inner.try_clone()?,
+        })
+    }
+
     /// Accepts a new incoming connection from this listener.
     ///
     /// This function will yield once a new TCP connection is established. When
@@ -157,6 +164,13 @@ impl TcpStream {
             Ok(Self { inner: socket })
         })
         .await
+    }
+
+    /// Creates a new independently owned handle to the underlying socket.
+    pub fn try_clone(&self) -> io::Result<Self> {
+        Ok(Self {
+            inner: self.inner.try_clone()?,
+        })
     }
 
     /// Returns the socket address of the remote peer of this TCP connection.

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -64,6 +64,8 @@ impl TcpListener {
     }
 
     /// Creates a new independently owned handle to the underlying socket.
+    ///
+    /// It does not clear the attach state.
     pub fn try_clone(&self) -> io::Result<Self> {
         Ok(Self {
             inner: self.inner.try_clone()?,
@@ -167,6 +169,8 @@ impl TcpStream {
     }
 
     /// Creates a new independently owned handle to the underlying socket.
+    ///
+    /// It does not clear the attach state.
     pub fn try_clone(&self) -> io::Result<Self> {
         Ok(Self {
             inner: self.inner.try_clone()?,

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -123,6 +123,8 @@ impl UdpSocket {
     }
 
     /// Creates a new independently owned handle to the underlying socket.
+    ///
+    /// It does not clear the attach state.
     pub fn try_clone(&self) -> io::Result<Self> {
         Ok(Self {
             inner: self.inner.try_clone()?,

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -122,6 +122,13 @@ impl UdpSocket {
         super::each_addr(addr, |addr| self.inner.connect(&addr))
     }
 
+    /// Creates a new independently owned handle to the underlying socket.
+    pub fn try_clone(&self) -> io::Result<Self> {
+        Ok(Self {
+            inner: self.inner.try_clone()?,
+        })
+    }
+
     /// Returns the socket address of the remote peer this socket was connected
     /// to.
     ///

--- a/src/net/unix.rs
+++ b/src/net/unix.rs
@@ -64,6 +64,8 @@ impl UnixListener {
     }
 
     /// Creates a new independently owned handle to the underlying socket.
+    ///
+    /// It does not clear the attach state.
     pub fn try_clone(&self) -> io::Result<Self> {
         Ok(Self {
             inner: self.inner.try_clone()?,
@@ -134,6 +136,8 @@ impl UnixStream {
     }
 
     /// Creates a new independently owned handle to the underlying socket.
+    ///
+    /// It does not clear the attach state.
     pub fn try_clone(&self) -> io::Result<Self> {
         Ok(Self {
             inner: self.inner.try_clone()?,

--- a/src/net/unix.rs
+++ b/src/net/unix.rs
@@ -63,6 +63,13 @@ impl UnixListener {
         })
     }
 
+    /// Creates a new independently owned handle to the underlying socket.
+    pub fn try_clone(&self) -> io::Result<Self> {
+        Ok(Self {
+            inner: self.inner.try_clone()?,
+        })
+    }
+
     /// Accepts a new incoming connection from this listener.
     ///
     /// This function will yield once a new Unix domain socket connection
@@ -123,6 +130,13 @@ impl UnixStream {
             socket.connect(&addr)?;
             let unix_stream = UnixStream { inner: socket };
             Ok(unix_stream)
+        })
+    }
+
+    /// Creates a new independently owned handle to the underlying socket.
+    pub fn try_clone(&self) -> io::Result<Self> {
+        Ok(Self {
+            inner: self.inner.try_clone()?,
         })
     }
 


### PR DESCRIPTION
Fixes #39 

This PR allows you to:
* Accept a stream from a listener, and move the stream *immediately* to another thread.
* Only attach the handle to the thread-local runtime at first call to an async method.
* Use IOCP without undocumented APIs.

And it disallows you to:
* Attach a handle to the driver multiple times.
* Attach a handle to multiple drivers.
* Move an attached handle to another thread.

Note about try_clone: it *doesn't* clear attach state.