### PR TITLE
Fix eagain on linux

### DIFF
--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -54,7 +54,9 @@ impl Socket {
 
     pub fn new(domain: Domain, ty: Type, protocol: Option<Protocol>) -> io::Result<Self> {
         let socket = Socket2::new(domain, ty, protocol)?;
-        #[cfg(unix)]
+        // on Linux and Windows we use native completion-based IO interfaces and are not
+        // interested to receive EAGAIN/EWOULDBLOCK as accept result
+        #[cfg(all(unix, not(target_os = "linux")))]
         socket.set_nonblocking(true)?;
         Ok(Self::from_socket2(socket))
     }

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -54,8 +54,11 @@ impl Socket {
 
     pub fn new(domain: Domain, ty: Type, protocol: Option<Protocol>) -> io::Result<Self> {
         let socket = Socket2::new(domain, ty, protocol)?;
-        // on Linux and Windows we use native completion-based IO interfaces and are not
-        // interested to receive EAGAIN/EWOULDBLOCK as accept result
+        // On Linux we use blocking socket
+        // Newer kernels have the patch that allows to arm io_uring poll mechanism for
+        // non blocking socket when there is no connections in listen queue
+        //
+        // https://patchwork.kernel.org/project/linux-block/patch/f999615b-205c-49b7-b272-c4e42e45e09d@kernel.dk/#22949861
         #[cfg(all(unix, not(target_os = "linux")))]
         socket.set_nonblocking(true)?;
         Ok(Self::from_socket2(socket))

--- a/tests/tcp_connect.rs
+++ b/tests/tcp_connect.rs
@@ -45,9 +45,11 @@ test_connect_ip! {
 async fn test_connect_impl<A: ToSockAddrs>(mapping: impl FnOnce(&TcpListener) -> A) {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = mapping(&listener);
-
     let server = async {
-        assert!(listener.accept().await.is_ok());
+        let res = listener.accept().await;
+        if let Err(err) = res {
+            panic!("{}", err);
+        }
     };
 
     let client = async {

--- a/tests/tcp_connect.rs
+++ b/tests/tcp_connect.rs
@@ -46,10 +46,7 @@ async fn test_connect_impl<A: ToSockAddrs>(mapping: impl FnOnce(&TcpListener) ->
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = mapping(&listener);
     let server = async {
-        let res = listener.accept().await;
-        if let Err(err) = res {
-            panic!("{}", err);
-        }
+        listener.accept().await.unwrap();
     };
 
     let client = async {


### PR DESCRIPTION
I've found the following patch - https://lore.kernel.org/all/a545c1ae-02a7-e7f1-5199-5cd67a52bb1e@kernel.dk/T/#mc720f37164873a8853bb1953515329c242a89a3b

Using blocking socket allows tests to pass on Linux 5.15.