### PR TITLE
add INVALID_FD constant to use as a default value of uninitialized file descriptor

### DIFF
--- a/src/driver/iocp/mod.rs
+++ b/src/driver/iocp/mod.rs
@@ -41,6 +41,9 @@ pub(crate) use windows_sys::Win32::Networking::WinSock::{
 /// Therefore, both could be seen as fd.
 pub type RawFd = RawHandle;
 
+/// Invalid file descriptor value could be used as an initial value of uninitialized file descriptor
+pub const INVALID_FD: RawFd = INVALID_HANDLE_VALUE;
+
 /// Extracts raw fds.
 pub trait AsRawFd {
     /// Extracts the raw fd.

--- a/src/driver/iour/mod.rs
+++ b/src/driver/iour/mod.rs
@@ -19,6 +19,9 @@ use crate::driver::{Entry, Operation, Poller};
 
 pub(crate) mod op;
 
+/// Invalid file descriptor value could be used as an initial value of uninitialized file descriptor
+pub const INVALID_FD: RawFd = -1;
+
 /// Abstraction of io-uring operations.
 pub trait OpCode {
     /// Create submission entry.

--- a/src/driver/mio/mod.rs
+++ b/src/driver/mio/mod.rs
@@ -19,6 +19,9 @@ use crate::driver::{Entry, Operation, Poller};
 
 pub(crate) mod op;
 
+/// Invalid file descriptor value could be used as an initial value of uninitialized file descriptor
+pub const INVALID_FD: RawFd = -1;
+
 /// Abstraction of operations.
 pub trait OpCode {
     /// Perform the operation before submit, and return [`Decision`] to


### PR DESCRIPTION
This PR adds INVALID_FD constant - clients could use it as a default value for unitialized file descriptor