### PR TITLE
Buffers with lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ assert_eq!(entry.user_data(), 0);
 
 // Resize the buffer by return value.
 let n = entry.into_result().unwrap();
-let mut buffer = op.into_inner().into_inner();
+let mut buffer = op.into_inner();
 unsafe {
     buffer.set_len(n);
 }

--- a/examples/driver.rs
+++ b/examples/driver.rs
@@ -22,7 +22,7 @@ fn main() {
     assert_eq!(entry.user_data(), 0);
 
     let n = entry.into_result().unwrap();
-    let mut buffer = op.into_inner().into_inner();
+    let mut buffer = op.into_inner();
     unsafe {
         buffer.set_len(n);
     }

--- a/src/buf/buf_wrapper.rs
+++ b/src/buf/buf_wrapper.rs
@@ -1,6 +1,82 @@
-use std::io::{IoSlice, IoSliceMut};
+use std::{
+    io::{IoSlice, IoSliceMut},
+    mem::MaybeUninit,
+};
 
 use crate::buf::*;
+
+/// Holds an immutable IO buffer and IoSlice.
+#[derive(Debug)]
+pub struct BufWrapper<'arena, T: 'arena> {
+    buffer: T,
+    io_slice: [IoSlice<'arena>; 1],
+}
+
+impl<'arena, T: IoBuf<'arena>> From<T> for BufWrapper<'arena, T> {
+    fn from(buffer: T) -> Self {
+        // SAFETY: buffer Unpin and could be self referenced
+        let io_slice = [IoSlice::new(unsafe {
+            &*(buffer.as_slice() as *const [u8])
+        })];
+        Self { buffer, io_slice }
+    }
+}
+
+impl<T> IntoInner for BufWrapper<'_, T> {
+    type Inner = T;
+
+    fn into_inner(self) -> Self::Inner {
+        self.buffer
+    }
+}
+
+/// Holds an mutable IO buffer and IoSliceMut.
+#[derive(Debug)]
+pub struct BufWrapperMut<'arena, T: 'arena> {
+    buffer: T,
+    io_slice_mut: [IoSliceMut<'arena>; 1],
+}
+
+impl<T> IntoInner for BufWrapperMut<'_, T> {
+    type Inner = T;
+
+    fn into_inner(self) -> Self::Inner {
+        self.buffer
+    }
+}
+
+impl<'arena, T: IoBufMut<'arena>> From<T> for BufWrapperMut<'arena, T> {
+    fn from(mut buffer: T) -> Self {
+        // SAFETY: buffer Unpin and could be self referenced
+        let io_slice_mut = [IoSliceMut::new(unsafe {
+            slice_assume_init_mut::<'arena>(buffer.as_uninit_slice() as *mut [MaybeUninit<u8>])
+        })];
+        Self {
+            buffer,
+            io_slice_mut,
+        }
+    }
+}
+
+unsafe fn slice_assume_init_mut<'arena>(slice: *mut [MaybeUninit<u8>]) -> &'arena mut [u8] {
+    unsafe { &mut *(slice as *mut [u8]) }
+}
+
+impl<'arena, T: IoBuf<'arena>> AsIoSlices<'arena> for BufWrapper<'arena, T> {
+    unsafe fn as_io_slices(&self) -> &[IoSlice<'arena>] {
+        &self.io_slice
+    }
+}
+
+impl<'arena, T: IoBufMut<'arena>> AsIoSlicesMut<'arena> for BufWrapperMut<'arena, T> {
+    unsafe fn as_io_slices_mut(&mut self) -> &mut [IoSliceMut<'arena>] {
+        &mut self.io_slice_mut
+    }
+
+    fn set_init(&mut self, len: usize) {
+        self.buffer.set_buf_init(len)
+    }
+}
 
 /// Fixed slice of IO buffers.
 #[derive(Debug)]
@@ -43,14 +119,14 @@ impl<'arena, T: IoBufMut<'arena>> From<Box<[T]>> for VectoredBufWrapper<'arena, 
 }
 
 impl<'arena, T: IoBuf<'arena>> AsIoSlices<'arena> for VectoredBufWrapper<'arena, T> {
-    unsafe fn as_io_slices(&self) -> OneOrSlice<IoSlice<'arena>> {
-        OneOrSlice::Slice(&self.io_slices)
+    unsafe fn as_io_slices(&self) -> &[IoSlice<'_>] {
+        &self.io_slices
     }
 }
 
 impl<'arena, T: IoBufMut<'arena>> AsIoSlicesMut<'arena> for VectoredBufWrapper<'arena, T> {
-    unsafe fn as_io_slices_mut(&mut self) -> OneOrSliceMut<IoSliceMut<'arena>> {
-        OneOrSliceMut::Slice(&mut self.io_slices_mut)
+    unsafe fn as_io_slices_mut(&mut self) -> &mut [IoSliceMut<'arena>] {
+        &mut self.io_slices_mut
     }
 
     fn set_init(&mut self, mut len: usize) {

--- a/src/buf/buf_wrapper.rs
+++ b/src/buf/buf_wrapper.rs
@@ -18,8 +18,8 @@ impl<T> IntoInner for VectoredBufWrapper<'_, T> {
     }
 }
 
-impl<'arena, T: IoBuf<'arena>> From<Box<[T]>> for VectoredBufWrapper<'arena, T> {
-    fn from(buffers: Box<[T]>) -> Self {
+impl<'arena, T: IoBufMut<'arena>> From<Box<[T]>> for VectoredBufWrapper<'arena, T> {
+    fn from(mut buffers: Box<[T]>) -> Self {
         let io_slices: Box<[IoSlice<'arena>]> = unsafe {
             buffers
                 .iter()
@@ -29,8 +29,8 @@ impl<'arena, T: IoBuf<'arena>> From<Box<[T]>> for VectoredBufWrapper<'arena, T> 
         };
         let io_slices_mut: Box<[IoSliceMut<'arena>]> = unsafe {
             buffers
-                .iter()
-                .map(|buf| IoSliceMut::new(&mut *(buf.as_slice() as *const _ as *mut _)))
+                .iter_mut()
+                .map(|buf| IoSliceMut::new(&mut *(buf.as_uninit_slice() as *mut _ as *mut _)))
                 .collect::<Vec<_>>()
                 .into_boxed_slice()
         };

--- a/src/buf/io_buf.rs
+++ b/src/buf/io_buf.rs
@@ -88,7 +88,8 @@ pub unsafe trait IoBuf<'arena>: Unpin + 'arena {
     }
 }
 
-unsafe impl<#[cfg(feature = "allocator_api")] A: Allocator + 'static> IoBuf<'static> for vec_alloc!(u8, A)
+unsafe impl<#[cfg(feature = "allocator_api")] A: Allocator + 'static> IoBuf<'static>
+    for vec_alloc!(u8, A)
 {
     fn as_buf_ptr(&self) -> *const u8 {
         self.as_ptr()
@@ -204,7 +205,7 @@ unsafe impl IoBuf<'static> for bytes::BytesMut {
 }
 
 #[cfg(feature = "read_buf")]
-unsafe impl IoBuf<'arena> for std::io::BorrowedBuf<'arena> {
+unsafe impl<'arena> IoBuf<'arena> for std::io::BorrowedBuf<'arena> {
     fn as_buf_ptr(&self) -> *const u8 {
         self.filled().as_ptr()
     }
@@ -289,7 +290,7 @@ unsafe impl IoBufMut<'static> for bytes::BytesMut {
 }
 
 #[cfg(feature = "read_buf")]
-unsafe impl IoBufMut<'arena> for std::io::BorrowedBuf<'arena> {
+unsafe impl<'arena> IoBufMut<'arena> for std::io::BorrowedBuf<'arena> {
     fn as_buf_mut_ptr(&mut self) -> *mut u8 {
         self.filled().as_ptr() as _
     }

--- a/src/buf/io_buf.rs
+++ b/src/buf/io_buf.rs
@@ -88,7 +88,7 @@ pub unsafe trait IoBuf<'arena>: Unpin + 'arena {
     }
 }
 
-unsafe impl<#[cfg(feature = "allocator_api")] A: Allocator + 'static> IoBuf<'static>
+unsafe impl<#[cfg(feature = "allocator_api")] A: Allocator + Unpin + 'static> IoBuf<'static>
     for vec_alloc!(u8, A)
 {
     fn as_buf_ptr(&self) -> *const u8 {
@@ -256,7 +256,7 @@ pub unsafe trait IoBufMut<'arena>: IoBuf<'arena> {
     fn set_buf_init(&mut self, len: usize);
 }
 
-unsafe impl<#[cfg(feature = "allocator_api")] A: Allocator + 'static> IoBufMut<'static>
+unsafe impl<#[cfg(feature = "allocator_api")] A: Allocator + Unpin + 'static> IoBufMut<'static>
     for vec_alloc!(u8, A)
 {
     fn as_buf_mut_ptr(&mut self) -> *mut u8 {

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -25,8 +25,8 @@ pub trait IntoInner {
     fn into_inner(self) -> Self::Inner;
 }
 
-impl<T: IntoInner, O> IntoInner for crate::BufResult<O, T> {
-    type Inner = crate::BufResult<O, T::Inner>;
+impl<'arena, T: IntoInner, O> IntoInner for crate::BufResult<'arena, O, T> {
+    type Inner = crate::BufResult<'arena, O, T::Inner>;
 
     fn into_inner(self) -> Self::Inner {
         (self.0, self.1.into_inner())

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -14,7 +14,7 @@ mod with_buf;
 pub(crate) use with_buf::*;
 
 mod buf_wrapper;
-pub(crate) use buf_wrapper::*;
+pub use buf_wrapper::VectoredBufWrapper;
 
 /// Trait to get the inner buffer of an operation or a result.
 pub trait IntoInner {

--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -14,7 +14,7 @@ mod with_buf;
 pub(crate) use with_buf::*;
 
 mod buf_wrapper;
-pub use buf_wrapper::VectoredBufWrapper;
+pub use buf_wrapper::{BufWrapper, BufWrapperMut, VectoredBufWrapper};
 
 /// Trait to get the inner buffer of an operation or a result.
 pub trait IntoInner {

--- a/src/buf/slice.rs
+++ b/src/buf/slice.rs
@@ -58,15 +58,15 @@ impl<T> Slice<T> {
     }
 }
 
-fn deref<T: IoBuf>(buffer: &T) -> &[u8] {
+fn deref<'arena, T: IoBuf<'arena>>(buffer: &T) -> &[u8] {
     unsafe { std::slice::from_raw_parts(buffer.as_buf_ptr(), buffer.buf_len()) }
 }
 
-fn deref_mut<T: IoBufMut>(buffer: &mut T) -> &mut [u8] {
+fn deref_mut<'arena, T: IoBufMut<'arena>>(buffer: &mut T) -> &mut [u8] {
     unsafe { std::slice::from_raw_parts_mut(buffer.as_buf_mut_ptr(), buffer.buf_len()) }
 }
 
-impl<T: IoBuf> Deref for Slice<T> {
+impl<'arena, T: IoBuf<'arena>> Deref for Slice<T> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
@@ -76,7 +76,7 @@ impl<T: IoBuf> Deref for Slice<T> {
     }
 }
 
-impl<T: IoBufMut> DerefMut for Slice<T> {
+impl<'arena, T: IoBufMut<'arena>> DerefMut for Slice<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         let bytes = deref_mut(&mut self.buffer);
         let end = self.end.min(bytes.len());
@@ -84,7 +84,7 @@ impl<T: IoBufMut> DerefMut for Slice<T> {
     }
 }
 
-unsafe impl<T: IoBuf> IoBuf for Slice<T> {
+unsafe impl<'arena, T: IoBuf<'arena>> IoBuf<'arena> for Slice<T> {
     fn as_buf_ptr(&self) -> *const u8 {
         deref(&self.buffer)[self.begin..].as_ptr()
     }
@@ -98,7 +98,7 @@ unsafe impl<T: IoBuf> IoBuf for Slice<T> {
     }
 }
 
-unsafe impl<T: IoBufMut> IoBufMut for Slice<T> {
+unsafe impl<'arena, T: IoBufMut<'arena>> IoBufMut<'arena> for Slice<T> {
     fn as_buf_mut_ptr(&mut self) -> *mut u8 {
         deref_mut(&mut self.buffer)[self.begin..].as_mut_ptr()
     }

--- a/src/buf/with_buf.rs
+++ b/src/buf/with_buf.rs
@@ -1,83 +1,17 @@
-use std::{
-    io::{IoSlice, IoSliceMut},
-    ops::{Deref, DerefMut},
-};
-
-use super::{IoBuf, IoBufMut};
+use std::io::{IoSlice, IoSliceMut};
 
 pub trait AsIoSlices<'arena>: 'arena {
     /// # Safety
     ///
     /// The return slice will not live longer than self.
-    unsafe fn as_io_slices(&self) -> OneOrSlice<IoSlice<'arena>>;
+    unsafe fn as_io_slices(&self) -> &[IoSlice<'_>];
 }
 
-pub trait AsIoSlicesMut<'arena>: AsIoSlices<'arena> {
+pub trait AsIoSlicesMut<'arena>: 'arena {
     /// # Safety
     ///
     /// The return slice will not live longer than self.
-    unsafe fn as_io_slices_mut(&mut self) -> OneOrSliceMut<IoSliceMut<'arena>>;
+    unsafe fn as_io_slices_mut(&mut self) -> &mut [IoSliceMut<'arena>];
 
     fn set_init(&mut self, len: usize);
-}
-
-#[derive(Debug)]
-pub enum OneOrSlice<'arena, T> {
-    One(T),
-    Slice(&'arena [T]),
-}
-
-impl<'arena, T> Deref for OneOrSlice<'arena, T> {
-    type Target = [T];
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            Self::One(one) => std::slice::from_ref(one),
-            Self::Slice(slice) => *slice,
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum OneOrSliceMut<'arena, T> {
-    One(T),
-    Slice(&'arena mut [T]),
-}
-
-impl<'arena, T> Deref for OneOrSliceMut<'arena, T> {
-    type Target = [T];
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            Self::One(one) => std::slice::from_ref(one),
-            Self::Slice(slice) => *slice,
-        }
-    }
-}
-
-impl<'arena, T> DerefMut for OneOrSliceMut<'arena, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        match self {
-            Self::One(one) => std::slice::from_mut(one),
-            Self::Slice(slice) => *slice,
-        }
-    }
-}
-
-impl<'arena, T: IoBuf<'arena>> AsIoSlices<'arena> for T {
-    unsafe fn as_io_slices(&self) -> OneOrSlice<IoSlice<'arena>> {
-        OneOrSlice::One(IoSlice::new(&*(self.as_slice() as *const _ as *const _)))
-    }
-}
-
-impl<'arena, T: IoBufMut<'arena>> AsIoSlicesMut<'arena> for T {
-    unsafe fn as_io_slices_mut(&mut self) -> OneOrSliceMut<IoSliceMut<'arena>> {
-        OneOrSliceMut::One(IoSliceMut::new(
-            &mut *(self.as_uninit_slice() as *mut _ as *mut _),
-        ))
-    }
-
-    fn set_init(&mut self, len: usize) {
-        self.set_buf_init(len)
-    }
 }

--- a/src/buf/with_buf.rs
+++ b/src/buf/with_buf.rs
@@ -17,18 +17,14 @@ pub trait AsIoSlices: WrapBuf {
     /// # Safety
     ///
     /// The return slice will not live longer than self.
-    /// It is static to provide convience from writing self-referenced
-    /// structure.
-    unsafe fn as_io_slices(&self) -> OneOrVec<IoSlice<'static>>;
+    unsafe fn as_io_slices(&self) -> OneOrVec<IoSlice<'_>>;
 }
 
 pub trait AsIoSlicesMut: WrapBufMut + AsIoSlices {
     /// # Safety
     ///
     /// The return slice will not live longer than self.
-    /// It is static to provide convience from writing self-referenced
-    /// structure.
-    unsafe fn as_io_slices_mut(&mut self) -> OneOrVec<IoSliceMut<'static>>;
+    unsafe fn as_io_slices_mut(&mut self) -> OneOrVec<IoSliceMut<'_>>;
 }
 
 #[derive(Debug)]

--- a/src/buf/with_buf.rs
+++ b/src/buf/with_buf.rs
@@ -3,52 +3,64 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use crate::buf::IntoInner;
+use super::{IoBuf, IoBufMut};
 
-pub trait WrapBuf: IntoInner {
-    fn new(buffer: Self::Inner) -> Self;
+pub trait AsIoSlices {
+    /// # Safety
+    ///
+    /// The return slice will not live longer than self.
+    unsafe fn as_io_slices(&self) -> OneOrSlice<IoSlice<'_>>;
 }
 
-pub trait WrapBufMut {
+pub trait AsIoSlicesMut: AsIoSlices {
+    /// # Safety
+    ///
+    /// The return slice will not live longer than self.
+    unsafe fn as_io_slices_mut(&mut self) -> OneOrSlice<IoSliceMut<'_>>;
+
     fn set_init(&mut self, len: usize);
 }
 
-pub trait AsIoSlices: WrapBuf {
-    /// # Safety
-    ///
-    /// The return slice will not live longer than self.
-    unsafe fn as_io_slices(&self) -> OneOrVec<IoSlice<'_>>;
-}
-
-pub trait AsIoSlicesMut: WrapBufMut + AsIoSlices {
-    /// # Safety
-    ///
-    /// The return slice will not live longer than self.
-    unsafe fn as_io_slices_mut(&mut self) -> OneOrVec<IoSliceMut<'_>>;
-}
-
 #[derive(Debug)]
-pub enum OneOrVec<T> {
+pub enum OneOrSlice<T> {
     One(T),
-    Vec(Vec<T>),
+    Slice(Box<[T]>),
 }
 
-impl<T> Deref for OneOrVec<T> {
+impl<T> Deref for OneOrSlice<T> {
     type Target = [T];
 
     fn deref(&self) -> &Self::Target {
         match self {
             Self::One(one) => std::slice::from_ref(one),
-            Self::Vec(vec) => vec,
+            Self::Slice(slice) => slice,
         }
     }
 }
 
-impl<T> DerefMut for OneOrVec<T> {
+impl<T> DerefMut for OneOrSlice<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
             Self::One(one) => std::slice::from_mut(one),
-            Self::Vec(vec) => vec,
+            Self::Slice(slice) => slice,
         }
+    }
+}
+
+impl<'arena, T: IoBuf<'arena>> AsIoSlices for T {
+    unsafe fn as_io_slices(&self) -> OneOrSlice<IoSlice<'_>> {
+        OneOrSlice::One(IoSlice::new(&*(self.as_slice() as *const _ as *const _)))
+    }
+}
+
+impl<'arena, T: IoBufMut<'arena>> AsIoSlicesMut for T {
+    unsafe fn as_io_slices_mut(&mut self) -> OneOrSlice<IoSliceMut<'_>> {
+        OneOrSlice::One(IoSliceMut::new(
+            &mut *(self.as_uninit_slice() as *mut _ as *mut _),
+        ))
+    }
+
+    fn set_init(&mut self, len: usize) {
+        self.set_buf_init(len)
     }
 }

--- a/src/buf/with_buf.rs
+++ b/src/buf/with_buf.rs
@@ -5,57 +5,74 @@ use std::{
 
 use super::{IoBuf, IoBufMut};
 
-pub trait AsIoSlices {
+pub trait AsIoSlices<'arena>: 'arena {
     /// # Safety
     ///
     /// The return slice will not live longer than self.
-    unsafe fn as_io_slices(&self) -> OneOrSlice<IoSlice<'_>>;
+    unsafe fn as_io_slices(&self) -> OneOrSlice<IoSlice<'arena>>;
 }
 
-pub trait AsIoSlicesMut: AsIoSlices {
+pub trait AsIoSlicesMut<'arena>: AsIoSlices<'arena> {
     /// # Safety
     ///
     /// The return slice will not live longer than self.
-    unsafe fn as_io_slices_mut(&mut self) -> OneOrSlice<IoSliceMut<'_>>;
+    unsafe fn as_io_slices_mut(&mut self) -> OneOrSliceMut<IoSliceMut<'arena>>;
 
     fn set_init(&mut self, len: usize);
 }
 
 #[derive(Debug)]
-pub enum OneOrSlice<T> {
+pub enum OneOrSlice<'arena, T> {
     One(T),
-    Slice(Box<[T]>),
+    Slice(&'arena [T]),
 }
 
-impl<T> Deref for OneOrSlice<T> {
+impl<'arena, T> Deref for OneOrSlice<'arena, T> {
     type Target = [T];
 
     fn deref(&self) -> &Self::Target {
         match self {
             Self::One(one) => std::slice::from_ref(one),
-            Self::Slice(slice) => slice,
+            Self::Slice(slice) => *slice,
         }
     }
 }
 
-impl<T> DerefMut for OneOrSlice<T> {
+#[derive(Debug)]
+pub enum OneOrSliceMut<'arena, T> {
+    One(T),
+    Slice(&'arena mut [T]),
+}
+
+impl<'arena, T> Deref for OneOrSliceMut<'arena, T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::One(one) => std::slice::from_ref(one),
+            Self::Slice(slice) => *slice,
+        }
+    }
+}
+
+impl<'arena, T> DerefMut for OneOrSliceMut<'arena, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
             Self::One(one) => std::slice::from_mut(one),
-            Self::Slice(slice) => slice,
+            Self::Slice(slice) => *slice,
         }
     }
 }
 
-impl<'arena, T: IoBuf<'arena>> AsIoSlices for T {
-    unsafe fn as_io_slices(&self) -> OneOrSlice<IoSlice<'_>> {
+impl<'arena, T: IoBuf<'arena>> AsIoSlices<'arena> for T {
+    unsafe fn as_io_slices(&self) -> OneOrSlice<IoSlice<'arena>> {
         OneOrSlice::One(IoSlice::new(&*(self.as_slice() as *const _ as *const _)))
     }
 }
 
-impl<'arena, T: IoBufMut<'arena>> AsIoSlicesMut for T {
-    unsafe fn as_io_slices_mut(&mut self) -> OneOrSlice<IoSliceMut<'_>> {
-        OneOrSlice::One(IoSliceMut::new(
+impl<'arena, T: IoBufMut<'arena>> AsIoSlicesMut<'arena> for T {
+    unsafe fn as_io_slices_mut(&mut self) -> OneOrSliceMut<IoSliceMut<'arena>> {
+        OneOrSliceMut::One(IoSliceMut::new(
             &mut *(self.as_uninit_slice() as *mut _ as *mut _),
         ))
     }

--- a/src/driver/iocp/op.rs
+++ b/src/driver/iocp/op.rs
@@ -278,12 +278,12 @@ impl OpCode for Connect {
 }
 
 /// Receive data from remote.
-pub struct RecvImpl<'arena, T: AsIoSlicesMut + Unpin + 'arena> {
+pub struct RecvImpl<T: AsIoSlicesMut + Unpin> {
     pub(crate) fd: RawFd,
     pub(crate) buffer: T,
 }
 
-impl<'arena, T: AsIoSlicesMut + Unpin + 'arena> RecvImpl<'arena, T> {
+impl<T: AsIoSlicesMut + Unpin> RecvImpl<T> {
     /// Create [`Recv`] or [`RecvVectored`].
     pub fn new(fd: RawFd, buffer: T::Inner) -> Self {
         Self {
@@ -293,7 +293,7 @@ impl<'arena, T: AsIoSlicesMut + Unpin + 'arena> RecvImpl<'arena, T> {
     }
 }
 
-impl<'arena, T: AsIoSlicesMut + Unpin + 'arena> IntoInner for RecvImpl<'arena, T> {
+impl<T: AsIoSlicesMut + Unpin> IntoInner for RecvImpl<T> {
     type Inner = T;
 
     fn into_inner(self) -> Self::Inner {
@@ -301,7 +301,7 @@ impl<'arena, T: AsIoSlicesMut + Unpin + 'arena> IntoInner for RecvImpl<'arena, T
     }
 }
 
-impl<'arena, T: AsIoSlicesMut + Unpin + 'arena> OpCode for RecvImpl<'arena, T> {
+impl<T: AsIoSlicesMut + Unpin> OpCode for RecvImpl<T> {
     unsafe fn operate(mut self: Pin<&mut Self>, optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
         let slices = self.buffer.as_io_slices_mut();
         let mut flags = 0;
@@ -320,12 +320,12 @@ impl<'arena, T: AsIoSlicesMut + Unpin + 'arena> OpCode for RecvImpl<'arena, T> {
 }
 
 /// Send data to remote.
-pub struct SendImpl<T: AsIoSlices + Unpin + 'arena> {
+pub struct SendImpl<T: AsIoSlices + Unpin> {
     pub(crate) fd: RawFd,
     pub(crate) buffer: T,
 }
 
-impl<'arena, T: AsIoSlices + Unpin + 'arena> SendImpl<'arena, T> {
+impl<T: AsIoSlices + Unpin> SendImpl<T> {
     /// Create [`Send`] or [`SendVectored`].
     pub fn new(fd: RawFd, buffer: T::Inner) -> Self {
         Self {
@@ -335,7 +335,7 @@ impl<'arena, T: AsIoSlices + Unpin + 'arena> SendImpl<'arena, T> {
     }
 }
 
-impl<'arena, T: AsIoSlices + Unpin + 'arena> IntoInner for SendImpl<'arena, T> {
+impl<T: AsIoSlices + Unpin> IntoInner for SendImpl<T> {
     type Inner = T;
 
     fn into_inner(self) -> Self::Inner {
@@ -343,7 +343,7 @@ impl<'arena, T: AsIoSlices + Unpin + 'arena> IntoInner for SendImpl<'arena, T> {
     }
 }
 
-impl<'arena, T: AsIoSlices + Unpin + 'arena> OpCode for SendImpl<'arena, T> {
+impl<T: AsIoSlices + Unpin> OpCode for SendImpl<T> {
     unsafe fn operate(self: Pin<&mut Self>, optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
         let slices = self.buffer.as_io_slices();
         let mut sent = 0;
@@ -361,14 +361,14 @@ impl<'arena, T: AsIoSlices + Unpin + 'arena> OpCode for SendImpl<'arena, T> {
 }
 
 /// Receive data and source address.
-pub struct RecvFromImpl<'arena, T: AsIoSlicesMut + Unpin + 'arena> {
+pub struct RecvFromImpl<T: AsIoSlicesMut + Unpin> {
     pub(crate) fd: RawFd,
     pub(crate) buffer: T,
     pub(crate) addr: SOCKADDR_STORAGE,
     pub(crate) addr_len: socklen_t,
 }
 
-impl<'arena, T: AsIoSlicesMut + Unpin + 'arena> RecvFromImpl<'arena, T> {
+impl<T: AsIoSlicesMut + Unpin> RecvFromImpl<T> {
     /// Create [`RecvFrom`] or [`RecvFromVectored`].
     pub fn new(fd: RawFd, buffer: T::Inner) -> Self {
         Self {
@@ -380,7 +380,7 @@ impl<'arena, T: AsIoSlicesMut + Unpin + 'arena> RecvFromImpl<'arena, T> {
     }
 }
 
-impl<'arena, T: AsIoSlicesMut + Unpin + 'arena> IntoInner for RecvFromImpl<'arena, T> {
+impl<T: AsIoSlicesMut + Unpin> IntoInner for RecvFromImpl<T> {
     type Inner = (T, SOCKADDR_STORAGE, socklen_t);
 
     fn into_inner(self) -> Self::Inner {
@@ -388,7 +388,7 @@ impl<'arena, T: AsIoSlicesMut + Unpin + 'arena> IntoInner for RecvFromImpl<'aren
     }
 }
 
-impl<'arena, T: AsIoSlicesMut + Unpin + 'arena> OpCode for RecvFromImpl<'arena, T> {
+impl<T: AsIoSlicesMut + Unpin> OpCode for RecvFromImpl<T> {
     unsafe fn operate(mut self: Pin<&mut Self>, optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
         let buffer = self.buffer.as_io_slices_mut();
         let mut flags = 0;
@@ -409,13 +409,13 @@ impl<'arena, T: AsIoSlicesMut + Unpin + 'arena> OpCode for RecvFromImpl<'arena, 
 }
 
 /// Send data to specified address.
-pub struct SendToImpl<'arena, T: AsIoSlices + 'arena> {
+pub struct SendToImpl<T: AsIoSlices> {
     pub(crate) fd: RawFd,
     pub(crate) buffer: T,
     pub(crate) addr: SockAddr,
 }
 
-impl<'arena, T: AsIoSlices + 'arena> SendToImpl<'arena, T> {
+impl<T: AsIoSlices> SendToImpl<T> {
     /// Create [`SendTo`] or [`SendToVectored`].
     pub fn new(fd: RawFd, buffer: T::Inner, addr: SockAddr) -> Self {
         Self {
@@ -426,7 +426,7 @@ impl<'arena, T: AsIoSlices + 'arena> SendToImpl<'arena, T> {
     }
 }
 
-impl<'arena, T: AsIoSlices + 'arena> IntoInner for SendToImpl<'arena, T> {
+impl<T: AsIoSlices> IntoInner for SendToImpl<T> {
     type Inner = T;
 
     fn into_inner(self) -> Self::Inner {
@@ -434,7 +434,7 @@ impl<'arena, T: AsIoSlices + 'arena> IntoInner for SendToImpl<'arena, T> {
     }
 }
 
-impl<'arena, T: AsIoSlices + 'arena> OpCode for SendToImpl<'arena, T> {
+impl<T: AsIoSlices> OpCode for SendToImpl<T> {
     unsafe fn operate(self: Pin<&mut Self>, optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
         let buffer = self.buffer.as_io_slices();
         let mut sent = 0;

--- a/src/driver/iour/mod.rs
+++ b/src/driver/iour/mod.rs
@@ -85,7 +85,8 @@ impl<'arena> Driver<'arena> {
         while !inner_squeue.is_full() {
             if let Some(mut op) = ops.next() {
                 // SAFETY: operation buffers are Unpin, pinning is not required
-                let entry = op.opcode().create_entry().user_data(op.user_data() as _);
+                let user_data = op.user_data();
+                let entry = op.opcode().create_entry().user_data(user_data as _);
                 unsafe { inner_squeue.push(&entry) }.expect("queue has enough space");
             } else {
                 ended_ops = true;

--- a/src/driver/iour/op.rs
+++ b/src/driver/iour/op.rs
@@ -64,13 +64,8 @@ impl OpCode for Connect {
 
 impl<T: AsIoSlicesMut + Unpin> OpCode for RecvImpl<T> {
     fn create_entry(mut self: Pin<&mut Self>) -> Entry {
-        self.slices = unsafe { self.buffer.as_io_slices_mut() };
-        opcode::Readv::new(
-            Fd(self.fd),
-            self.slices.as_ptr() as _,
-            self.slices.len() as _,
-        )
-        .build()
+        let mut slices = unsafe { self.buffer.as_io_slices_mut() };
+        opcode::Readv::new(Fd(self.fd), slices.as_ptr() as _, slices.len() as _).build()
     }
 }
 

--- a/src/driver/iour/op.rs
+++ b/src/driver/iour/op.rs
@@ -62,21 +62,21 @@ impl OpCode for Connect {
     }
 }
 
-impl<T: AsIoSlicesMut + Unpin> OpCode for RecvImpl<T> {
+impl<'arena, T: AsIoSlicesMut<'arena>> OpCode for RecvImpl<'arena, T> {
     fn create_entry(mut self: Pin<&mut Self>) -> Entry {
         let mut slices = unsafe { self.buffer.as_io_slices_mut() };
         opcode::Readv::new(Fd(self.fd), slices.as_ptr() as _, slices.len() as _).build()
     }
 }
 
-impl<T: AsIoSlices + Unpin> OpCode for SendImpl<T> {
+impl<'arena, T: AsIoSlices<'arena>> OpCode for SendImpl<'arena, T> {
     fn create_entry(mut self: Pin<&mut Self>) -> Entry {
         let slices = unsafe { self.buffer.as_io_slices() };
         opcode::Writev::new(Fd(self.fd), slices.as_ptr() as _, slices.len() as _).build()
     }
 }
 
-impl<T: AsIoSlicesMut + Unpin> OpCode for RecvFromImpl<T> {
+impl<'arena, T: AsIoSlicesMut<'arena>> OpCode for RecvFromImpl<'arena, T> {
     #[allow(clippy::no_effect)]
     fn create_entry(mut self: Pin<&mut Self>) -> Entry {
         self.set_msg();
@@ -84,7 +84,7 @@ impl<T: AsIoSlicesMut + Unpin> OpCode for RecvFromImpl<T> {
     }
 }
 
-impl<T: AsIoSlices + Unpin> OpCode for SendToImpl<T> {
+impl<'arena, T: AsIoSlices<'arena>> OpCode for SendToImpl<'arena, T> {
     #[allow(clippy::no_effect)]
     fn create_entry(mut self: Pin<&mut Self>) -> Entry {
         self.set_msg();

--- a/src/driver/mio/mod.rs
+++ b/src/driver/mio/mod.rs
@@ -28,7 +28,10 @@ pub trait OpCode {
 
     /// Perform the operation after received corresponding
     /// event.
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> io::Result<ControlFlow<usize>>;
+    fn on_event<'slice>(
+        self: Pin<&'slice mut Self>,
+        event: &Event,
+    ) -> io::Result<ControlFlow<usize>>;
 }
 
 /// Result of [`OpCode::pre_submit`].

--- a/src/driver/mio/mod.rs
+++ b/src/driver/mio/mod.rs
@@ -28,10 +28,7 @@ pub trait OpCode {
 
     /// Perform the operation after received corresponding
     /// event.
-    fn on_event<'slice>(
-        self: Pin<&'slice mut Self>,
-        event: &Event,
-    ) -> io::Result<ControlFlow<usize>>;
+    fn on_event(self: Pin<&mut Self>, event: &Event) -> io::Result<ControlFlow<usize>>;
 }
 
 /// Result of [`OpCode::pre_submit`].

--- a/src/driver/mio/op.rs
+++ b/src/driver/mio/op.rs
@@ -147,7 +147,7 @@ impl OpCode for Connect {
     }
 }
 
-impl<T: AsIoSlicesMut + Unpin> OpCode for RecvImpl<T> {
+impl<T: AsIoSlicesMut> OpCode for RecvImpl<T> {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
         Ok(Decision::wait_readable(self.fd))
     }
@@ -161,7 +161,7 @@ impl<T: AsIoSlicesMut + Unpin> OpCode for RecvImpl<T> {
     }
 }
 
-impl<T: AsIoSlices + Unpin> OpCode for SendImpl<T> {
+impl<T: AsIoSlices> OpCode for SendImpl<T> {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
         Ok(Decision::wait_writable(self.fd))
     }
@@ -174,7 +174,7 @@ impl<T: AsIoSlices + Unpin> OpCode for SendImpl<T> {
     }
 }
 
-impl<T: AsIoSlicesMut + Unpin> OpCode for RecvFromImpl<T> {
+impl<T: AsIoSlicesMut> OpCode for RecvFromImpl<T> {
     fn pre_submit(mut self: Pin<&mut Self>) -> io::Result<Decision> {
         self.set_msg();
         syscall!(recvmsg(self.fd, &mut self.msg, 0) or wait_readable(self.fd))
@@ -187,7 +187,7 @@ impl<T: AsIoSlicesMut + Unpin> OpCode for RecvFromImpl<T> {
     }
 }
 
-impl<T: AsIoSlices + Unpin> OpCode for SendToImpl<T> {
+impl<T: AsIoSlices> OpCode for SendToImpl<T> {
     fn pre_submit(mut self: Pin<&mut Self>) -> io::Result<Decision> {
         self.set_msg();
         syscall!(sendmsg(self.fd, &self.msg, 0) or wait_writable(self.fd))

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -32,7 +32,7 @@ cfg_if::cfg_if! {
 ///
 /// use arrayvec::ArrayVec;
 /// use compio::{
-///     buf::IntoInner,
+///     buf::{BufWrapper, BufWrapperMut, IntoInner},
 ///     driver::{AsRawFd, Driver, Entry, Poller},
 ///     net::UdpSocket,
 ///     op,
@@ -56,11 +56,11 @@ cfg_if::cfg_if! {
 /// driver.attach(other_socket.as_raw_fd()).unwrap();
 ///
 /// // write data
-/// let mut op_write = op::Send::new(socket.as_raw_fd(), "hello world");
+/// let mut op_write = op::Send::new(socket.as_raw_fd(), BufWrapper::from("hello world"));
 ///
 /// // read data
 /// let buf = Vec::with_capacity(32);
-/// let mut op_read = op::Recv::new(other_socket.as_raw_fd(), buf);
+/// let mut op_read = op::Recv::new(other_socket.as_raw_fd(), BufWrapperMut::from(buf));
 ///
 /// let ops = [(&mut op_write, 1).into(), (&mut op_read, 2).into()];
 /// let mut entries = ArrayVec::<Entry, 2>::new();
@@ -90,7 +90,7 @@ cfg_if::cfg_if! {
 ///     }
 /// }
 ///
-/// let mut buf = op_read.into_inner();
+/// let mut buf = op_read.into_inner().into_inner();
 /// unsafe { buf.set_len(n_bytes) };
 /// assert_eq!(buf, b"hello world");
 /// ```

--- a/src/driver/unix/op.rs
+++ b/src/driver/unix/op.rs
@@ -107,6 +107,7 @@ impl<'arena, T: AsIoSlicesMut<'arena>> RecvFromImpl<'arena, T> {
     }
 
     pub(crate) fn set_msg(&mut self) {
+        // SAFETY: IoSliceMut is Unpin
         let mut slices = unsafe { self.buffer.as_io_slices_mut() };
         self.msg = libc::msghdr {
             msg_name: &mut self.addr as *mut _ as _,
@@ -150,11 +151,12 @@ impl<'arena, T: AsIoSlices<'arena>> SendToImpl<'arena, T> {
     }
 
     pub(crate) fn set_msg(&mut self) {
-        let mut slices = unsafe { self.buffer.as_io_slices() };
+        // SAFETY: IoSlice is Unpin
+        let slices = unsafe { self.buffer.as_io_slices() };
         self.msg = libc::msghdr {
             msg_name: self.addr.as_ptr() as _,
             msg_namelen: self.addr.len(),
-            msg_iov: slices.as_mut_ptr() as _,
+            msg_iov: slices.as_ptr() as _,
             msg_iovlen: slices.len() as _,
             msg_control: std::ptr::null_mut(),
             msg_controllen: 0,

--- a/src/driver/unix/op.rs
+++ b/src/driver/unix/op.rs
@@ -1,12 +1,10 @@
-use std::io::{IoSlice, IoSliceMut};
-
 use libc::{sockaddr_storage, socklen_t};
 use socket2::SockAddr;
 
 #[cfg(doc)]
 use crate::op::*;
 use crate::{
-    buf::{AsIoSlices, AsIoSlicesMut, IntoInner, OneOrVec},
+    buf::{AsIoSlices, AsIoSlicesMut, IntoInner},
     driver::RawFd,
 };
 
@@ -41,11 +39,8 @@ pub struct RecvImpl<T: AsIoSlicesMut + Unpin> {
 
 impl<T: AsIoSlicesMut + Unpin> RecvImpl<T> {
     /// Create [`Recv`] or [`RecvVectored`].
-    pub fn new(fd: RawFd, buffer: T::Inner) -> Self {
-        Self {
-            fd,
-            buffer: T::new(buffer),
-        }
+    pub fn new(fd: RawFd, buffer: T) -> Self {
+        Self { fd, buffer }
     }
 }
 
@@ -65,11 +60,8 @@ pub struct SendImpl<T: AsIoSlices + Unpin> {
 
 impl<T: AsIoSlices + Unpin> SendImpl<T> {
     /// Create [`Send`] or [`SendVectored`].
-    pub fn new(fd: RawFd, buffer: T::Inner) -> Self {
-        Self {
-            fd,
-            buffer: T::new(buffer),
-        }
+    pub fn new(fd: RawFd, buffer: T) -> Self {
+        Self { fd, buffer }
     }
 }
 
@@ -91,10 +83,10 @@ pub struct RecvFromImpl<T: AsIoSlicesMut + Unpin> {
 
 impl<T: AsIoSlicesMut + Unpin> RecvFromImpl<T> {
     /// Create [`RecvFrom`] or [`RecvFromVectored`].
-    pub fn new(fd: RawFd, buffer: T::Inner) -> Self {
+    pub fn new(fd: RawFd, buffer: T) -> Self {
         Self {
             fd,
-            buffer: T::new(buffer),
+            buffer,
             addr: unsafe { std::mem::zeroed() },
             msg: unsafe { std::mem::zeroed() },
         }
@@ -132,10 +124,10 @@ pub struct SendToImpl<T: AsIoSlices + Unpin> {
 
 impl<T: AsIoSlices + Unpin> SendToImpl<T> {
     /// Create [`SendTo`] or [`SendToVectored`].
-    pub fn new(fd: RawFd, buffer: T::Inner, addr: SockAddr) -> Self {
+    pub fn new(fd: RawFd, buffer: T, addr: SockAddr) -> Self {
         Self {
             fd,
-            buffer: T::new(buffer),
+            buffer,
             addr,
             msg: unsafe { std::mem::zeroed() },
         }

--- a/src/driver/unix/op.rs
+++ b/src/driver/unix/op.rs
@@ -34,13 +34,13 @@ impl Accept {
 }
 
 /// Receive data from remote.
-pub struct RecvImpl<T: AsIoSlicesMut + Unpin> {
+pub struct RecvImpl<'slice, T: AsIoSlicesMut + Unpin + 'slice> {
     pub(crate) fd: RawFd,
     pub(crate) buffer: T,
-    pub(crate) slices: OneOrVec<IoSliceMut<'static>>,
+    pub(crate) slices: OneOrVec<IoSliceMut<'slice>>,
 }
 
-impl<T: AsIoSlicesMut + Unpin> RecvImpl<T> {
+impl<'slice, T: AsIoSlicesMut + Unpin> RecvImpl<'slice, T> {
     /// Create [`Recv`] or [`RecvVectored`].
     pub fn new(fd: RawFd, buffer: T::Inner) -> Self {
         Self {
@@ -51,7 +51,7 @@ impl<T: AsIoSlicesMut + Unpin> RecvImpl<T> {
     }
 }
 
-impl<T: AsIoSlicesMut + Unpin> IntoInner for RecvImpl<T> {
+impl<'slice, T: AsIoSlicesMut + Unpin> IntoInner for RecvImpl<'slice, T> {
     type Inner = T;
 
     fn into_inner(self) -> Self::Inner {
@@ -60,13 +60,13 @@ impl<T: AsIoSlicesMut + Unpin> IntoInner for RecvImpl<T> {
 }
 
 /// Send data to remote.
-pub struct SendImpl<T: AsIoSlices + Unpin> {
+pub struct SendImpl<'slice, T: AsIoSlices + Unpin + 'slice> {
     pub(crate) fd: RawFd,
     pub(crate) buffer: T,
-    pub(crate) slices: OneOrVec<IoSlice<'static>>,
+    pub(crate) slices: OneOrVec<IoSlice<'slice>>,
 }
 
-impl<T: AsIoSlices + Unpin> SendImpl<T> {
+impl<'slice, T: AsIoSlices + Unpin> SendImpl<'slice, T> {
     /// Create [`Send`] or [`SendVectored`].
     pub fn new(fd: RawFd, buffer: T::Inner) -> Self {
         Self {
@@ -77,7 +77,7 @@ impl<T: AsIoSlices + Unpin> SendImpl<T> {
     }
 }
 
-impl<T: AsIoSlices + Unpin> IntoInner for SendImpl<T> {
+impl<'slice, T: AsIoSlices + Unpin + 'slice> IntoInner for SendImpl<'slice, T> {
     type Inner = T;
 
     fn into_inner(self) -> Self::Inner {
@@ -86,15 +86,15 @@ impl<T: AsIoSlices + Unpin> IntoInner for SendImpl<T> {
 }
 
 /// Receive data and source address.
-pub struct RecvFromImpl<T: AsIoSlicesMut + Unpin> {
+pub struct RecvFromImpl<'slice, T: AsIoSlicesMut + Unpin + 'slice> {
     pub(crate) fd: RawFd,
     pub(crate) buffer: T,
     pub(crate) addr: sockaddr_storage,
-    pub(crate) slices: OneOrVec<IoSliceMut<'static>>,
+    pub(crate) slices: OneOrVec<IoSliceMut<'slice>>,
     pub(crate) msg: libc::msghdr,
 }
 
-impl<T: AsIoSlicesMut + Unpin> RecvFromImpl<T> {
+impl<'slice, T: AsIoSlicesMut + Unpin + 'slice> RecvFromImpl<'slice, T> {
     /// Create [`RecvFrom`] or [`RecvFromVectored`].
     pub fn new(fd: RawFd, buffer: T::Inner) -> Self {
         Self {
@@ -120,7 +120,7 @@ impl<T: AsIoSlicesMut + Unpin> RecvFromImpl<T> {
     }
 }
 
-impl<T: AsIoSlicesMut + Unpin> IntoInner for RecvFromImpl<T> {
+impl<'slice, T: AsIoSlicesMut + Unpin + 'slice> IntoInner for RecvFromImpl<'slice, T> {
     type Inner = (T, sockaddr_storage, socklen_t);
 
     fn into_inner(self) -> Self::Inner {
@@ -129,15 +129,15 @@ impl<T: AsIoSlicesMut + Unpin> IntoInner for RecvFromImpl<T> {
 }
 
 /// Send data to specified address.
-pub struct SendToImpl<T: AsIoSlices + Unpin> {
+pub struct SendToImpl<'slice, T: AsIoSlices + Unpin + 'slice> {
     pub(crate) fd: RawFd,
     pub(crate) buffer: T,
     pub(crate) addr: SockAddr,
-    pub(crate) slices: OneOrVec<IoSlice<'static>>,
+    pub(crate) slices: OneOrVec<IoSlice<'slice>>,
     pub(crate) msg: libc::msghdr,
 }
 
-impl<T: AsIoSlices + Unpin> SendToImpl<T> {
+impl<'slice, T: AsIoSlices + Unpin + 'slice> SendToImpl<'slice, T> {
     /// Create [`SendTo`] or [`SendToVectored`].
     pub fn new(fd: RawFd, buffer: T::Inner, addr: SockAddr) -> Self {
         Self {
@@ -163,7 +163,7 @@ impl<T: AsIoSlices + Unpin> SendToImpl<T> {
     }
 }
 
-impl<T: AsIoSlices + Unpin> IntoInner for SendToImpl<T> {
+impl<'slice, T: AsIoSlices + Unpin + 'slice> IntoInner for SendToImpl<'slice, T> {
     type Inner = T;
 
     fn into_inner(self) -> Self::Inner {

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -135,7 +135,6 @@ impl File {
             .await
             .into_inner()
             .map_advanced()
-            .into_inner()
     }
 
     /// Read the exact number of bytes required to fill `buffer`.
@@ -246,7 +245,6 @@ impl File {
         RUNTIME
             .with(|runtime| runtime.submit(op))
             .await
-            .into_inner()
             .into_inner()
     }
 

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -123,7 +123,11 @@ impl File {
     /// If this function encounters any form of I/O or other error, an error
     /// variant will be returned. The buffer is returned on error.
     #[cfg(feature = "runtime")]
-    pub async fn read_at<T: IoBufMut>(&self, buffer: T, pos: usize) -> BufResult<usize, T> {
+    pub async fn read_at<T: IoBufMut<'static>>(
+        &self,
+        buffer: T,
+        pos: usize,
+    ) -> BufResult<usize, T> {
         let ((), buffer) = buf_try!(self.attach(), buffer);
         let op = ReadAt::new(self.as_raw_fd(), pos, buffer);
         RUNTIME
@@ -155,7 +159,7 @@ impl File {
     ///
     /// [`ErrorKind::UnexpectedEof`]: io::ErrorKind::UnexpectedEof
     #[cfg(feature = "runtime")]
-    pub async fn read_exact_at<T: IoBufMut>(
+    pub async fn read_exact_at<T: IoBufMut<'static>>(
         &self,
         mut buffer: T,
         pos: usize,
@@ -236,7 +240,7 @@ impl File {
     /// It is **not** considered an error if the entire buffer could not be
     /// written to this writer.
     #[cfg(feature = "runtime")]
-    pub async fn write_at<T: IoBuf>(&self, buffer: T, pos: usize) -> BufResult<usize, T> {
+    pub async fn write_at<T: IoBuf<'static>>(&self, buffer: T, pos: usize) -> BufResult<usize, T> {
         let ((), buffer) = buf_try!(self.attach(), buffer);
         let op = WriteAt::new(self.as_raw_fd(), pos, buffer);
         RUNTIME
@@ -256,7 +260,11 @@ impl File {
     ///
     /// [`write_at`]: File::write_at
     #[cfg(feature = "runtime")]
-    pub async fn write_all_at<T: IoBuf>(&self, mut buffer: T, pos: usize) -> BufResult<usize, T> {
+    pub async fn write_all_at<T: IoBuf<'static>>(
+        &self,
+        mut buffer: T,
+        pos: usize,
+    ) -> BufResult<usize, T> {
         let buf_len = buffer.buf_len();
         let mut total_written = 0;
         let mut written;

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -197,7 +197,7 @@ impl File {
     ///
     /// [`read_at()`]: File::read_at
     #[cfg(feature = "runtime")]
-    pub async fn read_to_end_at<#[cfg(feature = "allocator_api")] A: Allocator + 'static>(
+    pub async fn read_to_end_at<#[cfg(feature = "allocator_api")] A: Allocator + Unpin + 'static>(
         &self,
         mut buffer: vec_alloc!(u8, A),
         pos: usize,

--- a/src/key.rs
+++ b/src/key.rs
@@ -2,10 +2,8 @@
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Key<T> {
     user_data: usize,
-    _p: std::marker::PhantomData<fn(T)>,
+    _not_send_not_sync: std::marker::PhantomData<*const T>,
 }
-
-impl<T> Unpin for Key<T> {}
 
 impl<T> Clone for Key<T> {
     fn clone(&self) -> Self {
@@ -26,7 +24,7 @@ impl<T> Key<T> {
     pub unsafe fn new(user_data: usize) -> Self {
         Self {
             user_data,
-            _p: std::marker::PhantomData,
+            _not_send_not_sync: std::marker::PhantomData,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub mod time;
 /// require passing ownership of a buffer to the runtime. When the operation
 /// completes, the buffer is returned whether or not the operation completed
 /// successfully.
-pub type BufResult<T, B> = (std::io::Result<T>, B);
+pub type BufResult<'arena, T, B: 'arena> = (std::io::Result<T>, B);
 
 #[cfg(feature = "runtime")]
 macro_rules! buf_try {
@@ -155,3 +155,19 @@ macro_rules! vec_alloc {
 }
 
 pub(crate) use vec_alloc;
+
+#[cfg(not(feature = "allocator_api"))]
+macro_rules! vec_alloc_lifetime {
+    () => {
+        'static
+    };
+}
+
+#[cfg(feature = "allocator_api")]
+macro_rules! vec_alloc_lifetime {
+    () => {
+        'a
+    };
+}
+
+pub(crate) use vec_alloc_lifetime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,19 +155,3 @@ macro_rules! vec_alloc {
 }
 
 pub(crate) use vec_alloc;
-
-#[cfg(not(feature = "allocator_api"))]
-macro_rules! vec_alloc_lifetime {
-    () => {
-        'static
-    };
-}
-
-#[cfg(feature = "allocator_api")]
-macro_rules! vec_alloc_lifetime {
-    () => {
-        'a
-    };
-}
-
-pub(crate) use vec_alloc_lifetime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub mod time;
 /// require passing ownership of a buffer to the runtime. When the operation
 /// completes, the buffer is returned whether or not the operation completed
 /// successfully.
-pub type BufResult<'arena, T, B: 'arena> = (std::io::Result<T>, B);
+pub type BufResult<'arena, T, B> = (std::io::Result<T>, B);
 
 #[cfg(feature = "runtime")]
 macro_rules! buf_try {

--- a/src/named_pipe.rs
+++ b/src/named_pipe.rs
@@ -214,25 +214,25 @@ impl NamedPipeServer {
     /// Read some bytes from the pipe into the specified
     /// buffer, returning how many bytes were read.
     #[cfg(feature = "runtime")]
-    pub async fn read<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn read<T: IoBufMut<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.handle.read_at(buffer, 0).await
     }
 
     /// Read the exact number of bytes from the pipe.
     #[cfg(feature = "runtime")]
-    pub async fn read_exact<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn read_exact<T: IoBufMut<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.handle.read_exact_at(buffer, 0).await
     }
 
     /// Write a buffer into the pipe, returning how many bytes were written.
     #[cfg(feature = "runtime")]
-    pub async fn write<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn write<T: IoBuf<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.handle.write_at(buffer, 0).await
     }
 
     /// Write all bytes into the pipe.
     #[cfg(feature = "runtime")]
-    pub async fn write_all<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn write_all<T: IoBuf<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.handle.write_all_at(buffer, 0).await
     }
 }
@@ -322,25 +322,25 @@ impl NamedPipeClient {
     /// Read some bytes from the pipe into the specified
     /// buffer, returning how many bytes were read.
     #[cfg(feature = "runtime")]
-    pub async fn read<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn read<T: IoBufMut<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.handle.read_at(buffer, 0).await
     }
 
     /// Read the exact number of bytes from the pipe.
     #[cfg(feature = "runtime")]
-    pub async fn read_exact<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn read_exact<T: IoBufMut<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.handle.read_exact_at(buffer, 0).await
     }
 
     /// Write a buffer into the pipe, returning how many bytes were written.
     #[cfg(feature = "runtime")]
-    pub async fn write<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn write<T: IoBuf<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.handle.write_at(buffer, 0).await
     }
 
     /// Write all bytes into the pipe.
     #[cfg(feature = "runtime")]
-    pub async fn write_all<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn write_all<T: IoBuf<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.handle.write_all_at(buffer, 0).await
     }
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -132,11 +132,11 @@ async fn each_addr_async<T, F: Future<Output = io::Result<T>>>(
 }
 
 #[allow(dead_code)]
-async fn each_addr_async_buf<T, B, F: Future<Output = BufResult<T, B>>>(
+async fn each_addr_async_buf<'arena, T, B: 'arena, F: Future<Output = BufResult<'arena, T, B>>>(
     addr: impl ToSockAddrs,
     mut buffer: B,
     mut f: impl FnMut(SockAddr, B) -> F,
-) -> BufResult<T, B> {
+) -> BufResult<'arena, T, B> {
     match addr.to_sock_addrs() {
         Ok(addrs) => {
             let mut last_err = None;

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -139,7 +139,6 @@ impl Socket {
             .await
             .into_inner()
             .map_advanced()
-            .into_inner()
     }
 
     #[cfg(feature = "runtime")]
@@ -184,7 +183,6 @@ impl Socket {
             .with(|runtime| runtime.submit(op))
             .await
             .into_inner()
-            .into_inner()
     }
 
     #[cfg(feature = "runtime")]
@@ -226,7 +224,6 @@ impl Socket {
             .into_inner()
             .map_addr()
             .map_advanced()
-            .into_inner()
     }
 
     #[cfg(feature = "runtime")]
@@ -255,7 +252,6 @@ impl Socket {
         RUNTIME
             .with(|runtime| runtime.submit(op))
             .await
-            .into_inner()
             .into_inner()
     }
 

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -131,7 +131,7 @@ impl Socket {
     }
 
     #[cfg(feature = "runtime")]
-    pub async fn recv<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn recv<T: IoBufMut<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         let ((), buffer) = buf_try!(self.attach(), buffer);
         let op = Recv::new(self.as_raw_fd(), buffer);
         RUNTIME
@@ -143,7 +143,7 @@ impl Socket {
     }
 
     #[cfg(feature = "runtime")]
-    pub async fn recv_exact<T: IoBufMut>(&self, mut buffer: T) -> BufResult<usize, T> {
+    pub async fn recv_exact<T: IoBufMut<'static>>(&self, mut buffer: T) -> BufResult<usize, T> {
         let need = buffer.as_uninit_slice().len();
         let mut total_read = 0;
         let mut read;
@@ -163,7 +163,10 @@ impl Socket {
     }
 
     #[cfg(feature = "runtime")]
-    pub async fn recv_vectored<T: IoBufMut>(&self, buffer: Vec<T>) -> BufResult<usize, Vec<T>> {
+    pub async fn recv_vectored<T: IoBufMut<'static>>(
+        &self,
+        buffer: Vec<T>,
+    ) -> BufResult<usize, Vec<T>> {
         let ((), buffer) = buf_try!(self.attach(), buffer);
         let op = RecvVectored::new(self.as_raw_fd(), buffer);
         RUNTIME
@@ -175,7 +178,7 @@ impl Socket {
     }
 
     #[cfg(feature = "runtime")]
-    pub async fn send<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn send<T: IoBuf<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         let ((), buffer) = buf_try!(self.attach(), buffer);
         let op = Send::new(self.as_raw_fd(), buffer);
         RUNTIME
@@ -186,7 +189,7 @@ impl Socket {
     }
 
     #[cfg(feature = "runtime")]
-    pub async fn send_all<T: IoBuf>(&self, mut buffer: T) -> BufResult<usize, T> {
+    pub async fn send_all<T: IoBuf<'static>>(&self, mut buffer: T) -> BufResult<usize, T> {
         let buf_len = buffer.buf_len();
         let mut total_written = 0;
         let mut written;
@@ -199,7 +202,10 @@ impl Socket {
     }
 
     #[cfg(feature = "runtime")]
-    pub async fn send_vectored<T: IoBuf>(&self, buffer: Vec<T>) -> BufResult<usize, Vec<T>> {
+    pub async fn send_vectored<T: IoBuf<'static>>(
+        &self,
+        buffer: Vec<T>,
+    ) -> BufResult<usize, Vec<T>> {
         let ((), buffer) = buf_try!(self.attach(), buffer);
         let op = SendVectored::new(self.as_raw_fd(), buffer);
         RUNTIME
@@ -210,7 +216,10 @@ impl Socket {
     }
 
     #[cfg(feature = "runtime")]
-    pub async fn recv_from<T: IoBufMut>(&self, buffer: T) -> BufResult<(usize, SockAddr), T> {
+    pub async fn recv_from<T: IoBufMut<'static>>(
+        &self,
+        buffer: T,
+    ) -> BufResult<(usize, SockAddr), T> {
         let ((), buffer) = buf_try!(self.attach(), buffer);
         let op = RecvFrom::new(self.as_raw_fd(), buffer);
         RUNTIME
@@ -223,7 +232,7 @@ impl Socket {
     }
 
     #[cfg(feature = "runtime")]
-    pub async fn recv_from_vectored<T: IoBufMut>(
+    pub async fn recv_from_vectored<T: IoBufMut<'static>>(
         &self,
         buffer: Vec<T>,
     ) -> BufResult<(usize, SockAddr), Vec<T>> {
@@ -239,7 +248,11 @@ impl Socket {
     }
 
     #[cfg(feature = "runtime")]
-    pub async fn send_to<T: IoBuf>(&self, buffer: T, addr: &SockAddr) -> BufResult<usize, T> {
+    pub async fn send_to<T: IoBuf<'static>>(
+        &self,
+        buffer: T,
+        addr: &SockAddr,
+    ) -> BufResult<usize, T> {
         let ((), buffer) = buf_try!(self.attach(), buffer);
         let op = SendTo::new(self.as_raw_fd(), buffer, addr.clone());
         RUNTIME
@@ -250,7 +263,7 @@ impl Socket {
     }
 
     #[cfg(feature = "runtime")]
-    pub async fn send_to_vectored<T: IoBuf>(
+    pub async fn send_to_vectored<T: IoBuf<'static>>(
         &self,
         buffer: Vec<T>,
         addr: &SockAddr,

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -4,7 +4,7 @@ use socket2::{Protocol, SockAddr, Type};
 
 #[cfg(feature = "runtime")]
 use crate::{
-    buf::{IoBuf, IoBufMut},
+    buf::{IoBuf, IoBufMut, VectoredBufWrapper},
     BufResult,
 };
 use crate::{
@@ -214,8 +214,8 @@ impl TcpStream {
     #[cfg(feature = "runtime")]
     pub async fn recv_vectored<T: IoBufMut<'static>>(
         &self,
-        buffer: Vec<T>,
-    ) -> BufResult<usize, Vec<T>> {
+        buffer: VectoredBufWrapper<'static, T>,
+    ) -> BufResult<usize, VectoredBufWrapper<'static, T>> {
         self.inner.recv_vectored(buffer).await
     }
 
@@ -237,8 +237,8 @@ impl TcpStream {
     #[cfg(feature = "runtime")]
     pub async fn send_vectored<T: IoBuf<'static>>(
         &self,
-        buffer: Vec<T>,
-    ) -> BufResult<usize, Vec<T>> {
+        buffer: VectoredBufWrapper<'static, T>,
+    ) -> BufResult<usize, VectoredBufWrapper<'static, T>> {
         self.inner.send_vectored(buffer).await
     }
 }

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -199,40 +199,46 @@ impl TcpStream {
     /// Receives a packet of data from the socket into the buffer, returning the
     /// original buffer and quantity of data received.
     #[cfg(feature = "runtime")]
-    pub async fn recv<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn recv<T: IoBufMut<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.recv(buffer).await
     }
 
     /// Receives exact number of bytes from the socket.
     #[cfg(feature = "runtime")]
-    pub async fn recv_exact<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn recv_exact<T: IoBufMut<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.recv_exact(buffer).await
     }
 
     /// Receives a packet of data from the socket into the buffer, returning the
     /// original buffer and quantity of data received.
     #[cfg(feature = "runtime")]
-    pub async fn recv_vectored<T: IoBufMut>(&self, buffer: Vec<T>) -> BufResult<usize, Vec<T>> {
+    pub async fn recv_vectored<T: IoBufMut<'static>>(
+        &self,
+        buffer: Vec<T>,
+    ) -> BufResult<usize, Vec<T>> {
         self.inner.recv_vectored(buffer).await
     }
 
     /// Sends some data to the socket from the buffer, returning the original
     /// buffer and quantity of data sent.
     #[cfg(feature = "runtime")]
-    pub async fn send<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn send<T: IoBuf<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.send(buffer).await
     }
 
     /// Sends all data to the socket.
     #[cfg(feature = "runtime")]
-    pub async fn send_all<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn send_all<T: IoBuf<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.send_all(buffer).await
     }
 
     /// Sends some data to the socket from the buffer, returning the original
     /// buffer and quantity of data sent.
     #[cfg(feature = "runtime")]
-    pub async fn send_vectored<T: IoBuf>(&self, buffer: Vec<T>) -> BufResult<usize, Vec<T>> {
+    pub async fn send_vectored<T: IoBuf<'static>>(
+        &self,
+        buffer: Vec<T>,
+    ) -> BufResult<usize, Vec<T>> {
         self.inner.send_vectored(buffer).await
     }
 }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -4,7 +4,7 @@ use socket2::{Protocol, SockAddr, Type};
 
 #[cfg(feature = "runtime")]
 use crate::{
-    buf::{IoBuf, IoBufMut},
+    buf::{IoBuf, IoBufMut, VectoredBufWrapper},
     BufResult,
 };
 use crate::{
@@ -190,8 +190,8 @@ impl UdpSocket {
     #[cfg(feature = "runtime")]
     pub async fn recv_vectored<T: IoBufMut<'static>>(
         &self,
-        buffer: Vec<T>,
-    ) -> BufResult<usize, Vec<T>> {
+        buffer: VectoredBufWrapper<'static, T>,
+    ) -> BufResult<usize, VectoredBufWrapper<'static, T>> {
         self.inner.recv_vectored(buffer).await
     }
 
@@ -207,8 +207,8 @@ impl UdpSocket {
     #[cfg(feature = "runtime")]
     pub async fn send_vectored<T: IoBuf<'static>>(
         &self,
-        buffer: Vec<T>,
-    ) -> BufResult<usize, Vec<T>> {
+        buffer: VectoredBufWrapper<'static, T>,
+    ) -> BufResult<usize, VectoredBufWrapper<'static, T>> {
         self.inner.send_vectored(buffer).await
     }
 
@@ -227,8 +227,8 @@ impl UdpSocket {
     #[cfg(feature = "runtime")]
     pub async fn recv_from_vectored<T: IoBufMut<'static>>(
         &self,
-        buffer: Vec<T>,
-    ) -> BufResult<(usize, SockAddr), Vec<T>> {
+        buffer: VectoredBufWrapper<'static, T>,
+    ) -> BufResult<(usize, SockAddr), VectoredBufWrapper<'static, T>> {
         self.inner.recv_from_vectored(buffer).await
     }
 
@@ -251,9 +251,9 @@ impl UdpSocket {
     #[cfg(feature = "runtime")]
     pub async fn send_to_vectored<T: IoBuf<'static>>(
         &self,
-        buffer: Vec<T>,
+        buffer: VectoredBufWrapper<'static, T>,
         addr: impl ToSockAddrs,
-    ) -> BufResult<usize, Vec<T>> {
+    ) -> BufResult<usize, VectoredBufWrapper<'static, T>> {
         super::each_addr_async_buf(addr, buffer, |addr, buffer| async move {
             self.inner.send_to_vectored(buffer, &addr).await
         })

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -181,42 +181,51 @@ impl UdpSocket {
     /// Receives a packet of data from the socket into the buffer, returning the
     /// original buffer and quantity of data received.
     #[cfg(feature = "runtime")]
-    pub async fn recv<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn recv<T: IoBufMut<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.recv(buffer).await
     }
 
     /// Receives a packet of data from the socket into the buffer, returning the
     /// original buffer and quantity of data received.
     #[cfg(feature = "runtime")]
-    pub async fn recv_vectored<T: IoBufMut>(&self, buffer: Vec<T>) -> BufResult<usize, Vec<T>> {
+    pub async fn recv_vectored<T: IoBufMut<'static>>(
+        &self,
+        buffer: Vec<T>,
+    ) -> BufResult<usize, Vec<T>> {
         self.inner.recv_vectored(buffer).await
     }
 
     /// Sends some data to the socket from the buffer, returning the original
     /// buffer and quantity of data sent.
     #[cfg(feature = "runtime")]
-    pub async fn send<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn send<T: IoBuf<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.send(buffer).await
     }
 
     /// Sends some data to the socket from the buffer, returning the original
     /// buffer and quantity of data sent.
     #[cfg(feature = "runtime")]
-    pub async fn send_vectored<T: IoBuf>(&self, buffer: Vec<T>) -> BufResult<usize, Vec<T>> {
+    pub async fn send_vectored<T: IoBuf<'static>>(
+        &self,
+        buffer: Vec<T>,
+    ) -> BufResult<usize, Vec<T>> {
         self.inner.send_vectored(buffer).await
     }
 
     /// Receives a single datagram message on the socket. On success, returns
     /// the number of bytes received and the origin.
     #[cfg(feature = "runtime")]
-    pub async fn recv_from<T: IoBufMut>(&self, buffer: T) -> BufResult<(usize, SockAddr), T> {
+    pub async fn recv_from<T: IoBufMut<'static>>(
+        &self,
+        buffer: T,
+    ) -> BufResult<(usize, SockAddr), T> {
         self.inner.recv_from(buffer).await
     }
 
     /// Receives a single datagram message on the socket. On success, returns
     /// the number of bytes received and the origin.
     #[cfg(feature = "runtime")]
-    pub async fn recv_from_vectored<T: IoBufMut>(
+    pub async fn recv_from_vectored<T: IoBufMut<'static>>(
         &self,
         buffer: Vec<T>,
     ) -> BufResult<(usize, SockAddr), Vec<T>> {
@@ -226,7 +235,7 @@ impl UdpSocket {
     /// Sends data on the socket to the given address. On success, returns the
     /// number of bytes sent.
     #[cfg(feature = "runtime")]
-    pub async fn send_to<T: IoBuf>(
+    pub async fn send_to<T: IoBuf<'static>>(
         &self,
         buffer: T,
         addr: impl ToSockAddrs,
@@ -240,7 +249,7 @@ impl UdpSocket {
     /// Sends data on the socket to the given address. On success, returns the
     /// number of bytes sent.
     #[cfg(feature = "runtime")]
-    pub async fn send_to_vectored<T: IoBuf>(
+    pub async fn send_to_vectored<T: IoBuf<'static>>(
         &self,
         buffer: Vec<T>,
         addr: impl ToSockAddrs,

--- a/src/net/unix.rs
+++ b/src/net/unix.rs
@@ -166,40 +166,46 @@ impl UnixStream {
     /// Receives a packet of data from the socket into the buffer, returning the
     /// original buffer and quantity of data received.
     #[cfg(feature = "runtime")]
-    pub async fn recv<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn recv<T: IoBufMut<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.recv(buffer).await
     }
 
     /// Receives exact number of bytes from the socket.
     #[cfg(feature = "runtime")]
-    pub async fn recv_exact<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn recv_exact<T: IoBufMut<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.recv_exact(buffer).await
     }
 
     /// Receives a packet of data from the socket into the buffer, returning the
     /// original buffer and quantity of data received.
     #[cfg(feature = "runtime")]
-    pub async fn recv_vectored<T: IoBufMut>(&self, buffer: Vec<T>) -> BufResult<usize, Vec<T>> {
+    pub async fn recv_vectored<T: IoBufMut<'static>>(
+        &self,
+        buffer: Vec<T>,
+    ) -> BufResult<usize, Vec<T>> {
         self.inner.recv_vectored(buffer).await
     }
 
     /// Sends some data to the socket from the buffer, returning the original
     /// buffer and quantity of data sent.
     #[cfg(feature = "runtime")]
-    pub async fn send<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn send<T: IoBuf<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.send(buffer).await
     }
 
     /// Sends all data to the socket.
     #[cfg(feature = "runtime")]
-    pub async fn send_all<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
+    pub async fn send_all<T: IoBuf<'static>>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.send_all(buffer).await
     }
 
     /// Sends some data to the socket from the buffer, returning the original
     /// buffer and quantity of data sent.
     #[cfg(feature = "runtime")]
-    pub async fn send_vectored<T: IoBuf>(&self, buffer: Vec<T>) -> BufResult<usize, Vec<T>> {
+    pub async fn send_vectored<T: IoBuf<'static>>(
+        &self,
+        buffer: Vec<T>,
+    ) -> BufResult<usize, Vec<T>> {
         self.inner.send_vectored(buffer).await
     }
 }

--- a/src/net/unix.rs
+++ b/src/net/unix.rs
@@ -4,7 +4,7 @@ use socket2::{Domain, SockAddr, Type};
 
 #[cfg(feature = "runtime")]
 use crate::{
-    buf::{IoBuf, IoBufMut},
+    buf::{IoBuf, IoBufMut, VectoredBufWrapper},
     BufResult,
 };
 use crate::{
@@ -181,8 +181,8 @@ impl UnixStream {
     #[cfg(feature = "runtime")]
     pub async fn recv_vectored<T: IoBufMut<'static>>(
         &self,
-        buffer: Vec<T>,
-    ) -> BufResult<usize, Vec<T>> {
+        buffer: VectoredBufWrapper<'static, T>,
+    ) -> BufResult<usize, VectoredBufWrapper<'static, T>> {
         self.inner.recv_vectored(buffer).await
     }
 
@@ -204,8 +204,8 @@ impl UnixStream {
     #[cfg(feature = "runtime")]
     pub async fn send_vectored<T: IoBuf<'static>>(
         &self,
-        buffer: Vec<T>,
-    ) -> BufResult<usize, Vec<T>> {
+        buffer: VectoredBufWrapper<'static, T>,
+    ) -> BufResult<usize, VectoredBufWrapper<'static, T>> {
         self.inner.send_vectored(buffer).await
     }
 }

--- a/src/op.rs
+++ b/src/op.rs
@@ -18,7 +18,7 @@ pub(crate) trait BufResultExt {
     fn map_advanced(self) -> Self;
 }
 
-impl<T: AsIoSlicesMut> BufResultExt for BufResult<usize, T> {
+impl<'arena, T: AsIoSlicesMut + 'arena> BufResultExt for BufResult<'arena, usize, T> {
     fn map_advanced(self) -> Self {
         let (res, buffer) = self;
         let (res, buffer) = (res.map(|res| (res, ())), buffer).map_advanced();
@@ -27,7 +27,7 @@ impl<T: AsIoSlicesMut> BufResultExt for BufResult<usize, T> {
     }
 }
 
-impl<T: AsIoSlicesMut, O> BufResultExt for BufResult<(usize, O), T> {
+impl<'arena, T: AsIoSlicesMut + 'arena, O> BufResultExt for BufResult<'arena, (usize, O), T> {
     fn map_advanced(self) -> Self {
         let (res, mut buffer) = self;
         if let Ok((init, _)) = &res {
@@ -43,8 +43,10 @@ pub(crate) trait RecvResultExt {
     fn map_addr(self) -> Self::RecvFromResult;
 }
 
-impl<T> RecvResultExt for BufResult<usize, (T, sockaddr_storage, socklen_t)> {
-    type RecvFromResult = BufResult<(usize, SockAddr), T>;
+impl<'arena, T: 'arena> RecvResultExt
+    for BufResult<'arena, usize, (T, sockaddr_storage, socklen_t)>
+{
+    type RecvFromResult = BufResult<'arena, (usize, SockAddr), T>;
 
     fn map_addr(self) -> Self::RecvFromResult {
         let (res, (buffer, addr_buffer, addr_size)) = self;
@@ -58,13 +60,13 @@ impl<T> RecvResultExt for BufResult<usize, (T, sockaddr_storage, socklen_t)> {
 
 /// Read a file at specified position into specified buffer.
 #[derive(Debug)]
-pub struct ReadAt<T: IoBufMut> {
+pub struct ReadAt<'arena, T: IoBufMut<'arena>> {
     pub(crate) fd: RawFd,
     pub(crate) offset: usize,
-    pub(crate) buffer: BufWrapper<T>,
+    pub(crate) buffer: BufWrapper<'arena, T>,
 }
 
-impl<T: IoBufMut> ReadAt<T> {
+impl<'arena, T: IoBufMut<'arena>> ReadAt<'arena, T> {
     /// Create [`ReadAt`].
     pub fn new(fd: RawFd, offset: usize, buffer: T) -> Self {
         Self {
@@ -75,8 +77,8 @@ impl<T: IoBufMut> ReadAt<T> {
     }
 }
 
-impl<T: IoBufMut> IntoInner for ReadAt<T> {
-    type Inner = BufWrapper<T>;
+impl<'arena, T: IoBufMut<'arena>> IntoInner for ReadAt<'arena, T> {
+    type Inner = BufWrapper<'arena, T>;
 
     fn into_inner(self) -> Self::Inner {
         self.buffer
@@ -85,13 +87,13 @@ impl<T: IoBufMut> IntoInner for ReadAt<T> {
 
 /// Write a file at specified position from specified buffer.
 #[derive(Debug)]
-pub struct WriteAt<T: IoBuf> {
+pub struct WriteAt<'arena, T: IoBuf<'arena>> {
     pub(crate) fd: RawFd,
     pub(crate) offset: usize,
-    pub(crate) buffer: BufWrapper<T>,
+    pub(crate) buffer: BufWrapper<'arena, T>,
 }
 
-impl<T: IoBuf> WriteAt<T> {
+impl<'arena, T: IoBuf<'arena>> WriteAt<'arena, T> {
     /// Create [`WriteAt`].
     pub fn new(fd: RawFd, offset: usize, buffer: T) -> Self {
         Self {
@@ -102,8 +104,8 @@ impl<T: IoBuf> WriteAt<T> {
     }
 }
 
-impl<T: IoBuf> IntoInner for WriteAt<T> {
-    type Inner = BufWrapper<T>;
+impl<'arena, T: IoBuf<'arena>> IntoInner for WriteAt<'arena, T> {
+    type Inner = BufWrapper<'arena, T>;
 
     fn into_inner(self) -> Self::Inner {
         self.buffer
@@ -146,21 +148,21 @@ impl Connect {
 }
 
 /// Receive data with one buffer.
-pub type Recv<T> = RecvImpl<BufWrapper<T>>;
+pub type Recv<'slice, T> = RecvImpl<'slice, BufWrapper<'slice, T>>;
 /// Receive data with vectored buffer.
-pub type RecvVectored<T> = RecvImpl<VectoredBufWrapper<T>>;
+pub type RecvVectored<T> = RecvImpl<'static, VectoredBufWrapper<T>>;
 
 /// Send data with one buffer.
-pub type Send<T> = SendImpl<BufWrapper<T>>;
+pub type Send<'slice, T> = SendImpl<'slice, BufWrapper<'slice, T>>;
 /// Send data with vectored buffer.
-pub type SendVectored<T> = SendImpl<VectoredBufWrapper<T>>;
+pub type SendVectored<T> = SendImpl<'static, VectoredBufWrapper<T>>;
 
 /// Receive data and address with one buffer.
-pub type RecvFrom<T> = RecvFromImpl<BufWrapper<T>>;
+pub type RecvFrom<'slice, T> = RecvFromImpl<'slice, BufWrapper<'slice, T>>;
 /// Receive data and address with vectored buffer.
-pub type RecvFromVectored<T> = RecvFromImpl<VectoredBufWrapper<T>>;
+pub type RecvFromVectored<T> = RecvFromImpl<'static, VectoredBufWrapper<T>>;
 
 /// Send data to address with one buffer.
-pub type SendTo<T> = SendToImpl<BufWrapper<T>>;
+pub type SendTo<'slice, T> = SendToImpl<'slice, BufWrapper<'slice, T>>;
 /// Send data to address with vectored buffer.
-pub type SendToVectored<T> = SendToImpl<VectoredBufWrapper<T>>;
+pub type SendToVectored<T> = SendToImpl<'static, VectoredBufWrapper<T>>;

--- a/src/op.rs
+++ b/src/op.rs
@@ -20,7 +20,7 @@ pub(crate) trait BufResultExt {
     fn map_advanced(self) -> Self;
 }
 
-impl<'arena, T: AsIoSlicesMut> BufResultExt for BufResult<'arena, usize, T> {
+impl<'arena, T: AsIoSlicesMut<'arena>> BufResultExt for BufResult<'arena, usize, T> {
     fn map_advanced(self) -> Self {
         let (res, buffer) = self;
         let (res, buffer) = (res.map(|res| (res, ())), buffer).map_advanced();
@@ -29,7 +29,7 @@ impl<'arena, T: AsIoSlicesMut> BufResultExt for BufResult<'arena, usize, T> {
     }
 }
 
-impl<'arena, T: AsIoSlicesMut, O> BufResultExt for BufResult<'arena, (usize, O), T> {
+impl<'arena, T: AsIoSlicesMut<'arena>, O> BufResultExt for BufResult<'arena, (usize, O), T> {
     fn map_advanced(self) -> Self {
         let (res, mut buffer) = self;
         if let Ok((init, _)) = &res {
@@ -154,21 +154,21 @@ impl Connect {
 }
 
 /// Receive data with one buffer.
-pub type Recv<T> = RecvImpl<T>;
+pub type Recv<'arena, T> = RecvImpl<'arena, T>;
 /// Receive data with vectored buffer.
-pub type RecvVectored<'arena, T> = RecvImpl<VectoredBufWrapper<'arena, T>>;
+pub type RecvVectored<'arena, T> = RecvImpl<'arena, VectoredBufWrapper<'arena, T>>;
 
 /// Send data with one buffer.
-pub type Send<T> = SendImpl<T>;
+pub type Send<'arena, T> = SendImpl<'arena, T>;
 /// Send data with vectored buffer.
-pub type SendVectored<'arena, T> = SendImpl<VectoredBufWrapper<'arena, T>>;
+pub type SendVectored<'arena, T> = SendImpl<'arena, VectoredBufWrapper<'arena, T>>;
 
 /// Receive data and address with one buffer.
-pub type RecvFrom<T> = RecvFromImpl<T>;
+pub type RecvFrom<'arena, T> = RecvFromImpl<'arena, T>;
 /// Receive data and address with vectored buffer.
-pub type RecvFromVectored<'arena, T> = RecvFromImpl<VectoredBufWrapper<'arena, T>>;
+pub type RecvFromVectored<'arena, T> = RecvFromImpl<'arena, VectoredBufWrapper<'arena, T>>;
 
 /// Send data to address with one buffer.
-pub type SendTo<T> = SendToImpl<T>;
+pub type SendTo<'arena, T> = SendToImpl<'arena, T>;
 /// Send data to address with vectored buffer.
-pub type SendToVectored<'arena, T> = SendToImpl<VectoredBufWrapper<'arena, T>>;
+pub type SendToVectored<'arena, T> = SendToImpl<'arena, VectoredBufWrapper<'arena, T>>;

--- a/src/op.rs
+++ b/src/op.rs
@@ -18,7 +18,7 @@ pub(crate) trait BufResultExt {
     fn map_advanced(self) -> Self;
 }
 
-impl<'arena, T: AsIoSlicesMut + 'arena> BufResultExt for BufResult<'arena, usize, T> {
+impl<'arena, T: AsIoSlicesMut> BufResultExt for BufResult<'arena, usize, T> {
     fn map_advanced(self) -> Self {
         let (res, buffer) = self;
         let (res, buffer) = (res.map(|res| (res, ())), buffer).map_advanced();
@@ -27,7 +27,7 @@ impl<'arena, T: AsIoSlicesMut + 'arena> BufResultExt for BufResult<'arena, usize
     }
 }
 
-impl<'arena, T: AsIoSlicesMut + 'arena, O> BufResultExt for BufResult<'arena, (usize, O), T> {
+impl<'arena, T: AsIoSlicesMut, O> BufResultExt for BufResult<'arena, (usize, O), T> {
     fn map_advanced(self) -> Self {
         let (res, mut buffer) = self;
         if let Ok((init, _)) = &res {
@@ -148,21 +148,21 @@ impl Connect {
 }
 
 /// Receive data with one buffer.
-pub type Recv<'slice, T> = RecvImpl<'slice, BufWrapper<'slice, T>>;
+pub type Recv<'arena, T> = RecvImpl<BufWrapper<'arena, T>>;
 /// Receive data with vectored buffer.
-pub type RecvVectored<T> = RecvImpl<'static, VectoredBufWrapper<T>>;
+pub type RecvVectored<T> = RecvImpl<VectoredBufWrapper<T>>;
 
 /// Send data with one buffer.
-pub type Send<'slice, T> = SendImpl<'slice, BufWrapper<'slice, T>>;
+pub type Send<'arena, T> = SendImpl<BufWrapper<'arena, T>>;
 /// Send data with vectored buffer.
-pub type SendVectored<T> = SendImpl<'static, VectoredBufWrapper<T>>;
+pub type SendVectored<T> = SendImpl<VectoredBufWrapper<T>>;
 
 /// Receive data and address with one buffer.
-pub type RecvFrom<'slice, T> = RecvFromImpl<'slice, BufWrapper<'slice, T>>;
+pub type RecvFrom<'arena, T> = RecvFromImpl<BufWrapper<'arena, T>>;
 /// Receive data and address with vectored buffer.
-pub type RecvFromVectored<T> = RecvFromImpl<'static, VectoredBufWrapper<T>>;
+pub type RecvFromVectored<T> = RecvFromImpl<VectoredBufWrapper<T>>;
 
 /// Send data to address with one buffer.
-pub type SendTo<'slice, T> = SendToImpl<'slice, BufWrapper<'slice, T>>;
+pub type SendTo<'arena, T> = SendToImpl<BufWrapper<'arena, T>>;
 /// Send data to address with vectored buffer.
-pub type SendToVectored<T> = SendToImpl<'static, VectoredBufWrapper<T>>;
+pub type SendToVectored<T> = SendToImpl<VectoredBufWrapper<T>>;

--- a/src/task/runtime.rs
+++ b/src/task/runtime.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 pub(crate) struct Runtime {
-    driver: RefCell<Driver>,
+    driver: RefCell<Driver<'static>>,
     runnables: RefCell<VecDeque<Runnable>>,
     squeue: RefCell<VecDeque<usize>>,
     op_runtime: RefCell<OpRuntime>,

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -77,7 +77,7 @@ fn drop_on_complete() {
         _ref_cnt: Arc<()>,
     }
 
-    unsafe impl IoBuf for MyBuf {
+    unsafe impl IoBuf<'static> for MyBuf {
         fn as_buf_ptr(&self) -> *const u8 {
             self.data.as_buf_ptr()
         }
@@ -91,7 +91,7 @@ fn drop_on_complete() {
         }
     }
 
-    unsafe impl IoBufMut for MyBuf {
+    unsafe impl IoBufMut<'static> for MyBuf {
         fn as_buf_mut_ptr(&mut self) -> *mut u8 {
             self.data.as_buf_mut_ptr()
         }


### PR DESCRIPTION
The goal of these PR is to enable to do IO against not 'static buffers.

This allows to preallocate buffer pool before IO driver is created even from non 'static memory allocator.

The implementation is done on Driver/op level because the async runtime is designed to be 'static.

Many entities have `'arena' lifetime.

The PR also includes the following changes:

* VectoredBufWrapper is moved to public API. This allows to initialize slices of `IoSlice` and `IoSliceMut` only once and don't allocate them on each vectored IO
* BufWrapper is split to BufWrapper and BufWrapperMut - they keep IoSlice/IoSliceMut allongside with the wrapped buffer.
This enables IoSlice to have the same 'arena lifetime. Send/Recv operations require wrapped buffers.
* IoBuf is required to be Unpin - this simplifies OpCode interfaces and allows to remove pinning. User is encoraged to use safely movable buffers and process them in different parts of application.
* Removed unsafe code from WaitEntry and extended Driver/Poller with `'arena` lifetime