### PR TITLE
Make `EventHandle` owns the fd.

### DIFF
--- a/src/event/iocp.rs
+++ b/src/event/iocp.rs
@@ -21,8 +21,8 @@ impl Event {
     }
 
     /// Get a notify handle.
-    pub fn handle(&self) -> EventHandle {
-        EventHandle::new(&self.user_data)
+    pub fn handle(&self) -> io::Result<EventHandle> {
+        Ok(EventHandle::new(&self.user_data))
     }
 
     /// Wait for [`EventHandle::notify`] called.

--- a/src/event/iocp.rs
+++ b/src/event/iocp.rs
@@ -1,4 +1,4 @@
-use std::{io, marker::PhantomData};
+use std::io;
 
 use crate::{
     driver::{post_driver, RawFd},
@@ -34,23 +34,21 @@ impl Event {
 }
 
 /// A handle to [`Event`].
-pub struct EventHandle<'a> {
+pub struct EventHandle {
     user_data: usize,
     handle: RawFd,
-    _p: PhantomData<&'a Event>,
 }
 
 // Safety: IOCP handle is thread safe.
-unsafe impl Send for EventHandle<'_> {}
-unsafe impl Sync for EventHandle<'_> {}
+unsafe impl Send for EventHandle {}
+unsafe impl Sync for EventHandle {}
 
-impl<'a> EventHandle<'a> {
-    pub(crate) fn new(user_data: &'a Key<()>) -> Self {
+impl EventHandle {
+    pub(crate) fn new(user_data: &Key<()>) -> Self {
         let handle = RUNTIME.with(|runtime| runtime.raw_driver());
         Self {
             user_data: **user_data,
             handle,
-            _p: PhantomData,
         }
     }
 

--- a/src/event/iour.rs
+++ b/src/event/iour.rs
@@ -1,6 +1,6 @@
 use std::{
     io,
-    os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd},
+    os::fd::{AsRawFd, FromRawFd, OwnedFd},
 };
 
 use crate::{impl_raw_fd, op::ReadAt, task::RUNTIME};
@@ -24,8 +24,8 @@ impl Event {
     }
 
     /// Get a notify handle.
-    pub fn handle(&self) -> EventHandle {
-        EventHandle::new(self.fd.as_fd())
+    pub fn handle(&self) -> io::Result<EventHandle> {
+        Ok(EventHandle::new(self.fd.try_clone()?))
     }
 
     /// Wait for [`EventHandle::notify`] called.
@@ -41,12 +41,12 @@ impl Event {
 impl_raw_fd!(Event, fd);
 
 /// A handle to [`Event`].
-pub struct EventHandle<'a> {
-    fd: BorrowedFd<'a>,
+pub struct EventHandle {
+    fd: OwnedFd,
 }
 
-impl<'a> EventHandle<'a> {
-    pub(crate) fn new(fd: BorrowedFd<'a>) -> Self {
+impl EventHandle {
+    pub(crate) fn new(fd: OwnedFd) -> Self {
         Self { fd }
     }
 
@@ -67,3 +67,5 @@ impl<'a> EventHandle<'a> {
         }
     }
 }
+
+impl_raw_fd!(EventHandle, fd);

--- a/src/event/mio.rs
+++ b/src/event/mio.rs
@@ -5,7 +5,7 @@ use std::{
 
 use mio::unix::pipe::Receiver;
 
-use crate::{op::Recv, task::RUNTIME};
+use crate::{impl_raw_fd, op::Recv, task::RUNTIME};
 
 /// An event that won't wake until [`EventHandle::notify`] is called
 /// successfully.
@@ -72,3 +72,5 @@ impl EventHandle {
         }
     }
 }
+
+impl_raw_fd!(EventHandle, fd);

--- a/src/signal/windows.rs
+++ b/src/signal/windows.rs
@@ -21,8 +21,7 @@ use windows_sys::Win32::{
 
 use crate::event::{Event, EventHandle};
 
-#[allow(clippy::type_complexity)]
-static HANDLER: LazyLock<Mutex<HashMap<u32, Slab<EventHandle<'static>>>>> =
+static HANDLER: LazyLock<Mutex<HashMap<u32, Slab<EventHandle>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 unsafe extern "system" fn ctrl_event_handler(ctrltype: u32) -> BOOL {
@@ -53,8 +52,6 @@ fn init() -> io::Result<()> {
 fn register(ctrltype: u32, e: &Event) -> usize {
     let mut handler = HANDLER.lock().unwrap();
     let handle = e.handle();
-    // Safety: we will unregister on drop.
-    let handle: EventHandle<'static> = unsafe { std::mem::transmute(handle) };
     handler.entry(ctrltype).or_default().insert(handle)
 }
 

--- a/src/signal/windows.rs
+++ b/src/signal/windows.rs
@@ -49,10 +49,10 @@ fn init() -> io::Result<()> {
     }
 }
 
-fn register(ctrltype: u32, e: &Event) -> usize {
+fn register(ctrltype: u32, e: &Event) -> io::Result<usize> {
     let mut handler = HANDLER.lock().unwrap();
-    let handle = e.handle();
-    handler.entry(ctrltype).or_default().insert(handle)
+    let handle = e.handle()?;
+    Ok(handler.entry(ctrltype).or_default().insert(handle))
 }
 
 fn unregister(ctrltype: u32, key: usize) {
@@ -77,7 +77,7 @@ impl CtrlEvent {
         INIT.call_once(|| init().unwrap());
 
         let event = Event::new()?;
-        let handler_key = register(ctrltype, &event);
+        let handler_key = register(ctrltype, &event)?;
         Ok(Self {
             ctrltype,
             event,

--- a/tests/event.rs
+++ b/tests/event.rs
@@ -4,7 +4,7 @@ use compio::event::Event;
 fn event_handle() {
     compio::task::block_on(async {
         let event = Event::new().unwrap();
-        let handle = event.handle();
+        let handle = event.handle().unwrap();
         std::thread::scope(|scope| {
             scope.spawn(|| handle.notify().unwrap());
         });


### PR DESCRIPTION
Users may forget the signal future, making the event handle dangling.