### PR TITLE
Make driver safe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ cfg-if = "1"
 futures-util = { version = "0.3", optional = true }
 # may be excluded from linking if the unstable equivalent is used
 once_cell = "1"
-slab = { version = "0.4", optional = true }
+slab = "0.4"
 smallvec = { version = "1", optional = true }
 socket2 = { version = ">=0.5.4", features = ["all"] }
 
@@ -80,7 +80,7 @@ libc = "0.2"
 
 [features]
 default = ["runtime"]
-runtime = ["dep:async-task", "dep:futures-util", "dep:slab", "dep:smallvec"]
+runtime = ["dep:async-task", "dep:futures-util", "dep:smallvec"]
 event = ["runtime", "arrayvec"]
 signal = ["event"]
 time = ["runtime"]

--- a/README.md
+++ b/README.md
@@ -40,42 +40,4 @@ let buffer = block_on(async {
 println!("{}", buffer);
 ```
 
-While you can also control the low-level driver manually:
-
-```rust,no_run
-use arrayvec::ArrayVec;
-use compio::{
-    buf::IntoInner,
-    driver::{AsRawFd, Driver, Entry, Poller},
-    fs::File,
-    op::ReadAt,
-};
-
-let mut driver = Driver::new().unwrap();
-let file = File::open("Cargo.toml").unwrap();
-// Attach the `RawFd` to driver first.
-driver.attach(file.as_raw_fd()).unwrap();
-
-// Create operation and push it to the driver.
-let mut op = ReadAt::new(file.as_raw_fd(), 0, Vec::with_capacity(4096));
-let ops = [(&mut op, 0).into()];
-
-// Poll the driver and wait for IO completed.
-let mut entries = ArrayVec::<Entry, 1>::new();
-unsafe {
-    driver
-        .poll(None, &mut ops.into_iter(), &mut entries)
-        .unwrap();
-}
-let entry = entries.drain(..).next().unwrap();
-assert_eq!(entry.user_data(), 0);
-
-// Resize the buffer by return value.
-let n = entry.into_result().unwrap();
-let mut buffer = op.into_inner().into_inner();
-unsafe {
-    buffer.set_len(n);
-}
-
-println!("{}", String::from_utf8(buffer).unwrap());
-```
+While you can also control the low-level driver manually. See `driver` example of the repo.

--- a/examples/driver.rs
+++ b/examples/driver.rs
@@ -19,7 +19,7 @@ fn main() {
     let n = res.unwrap();
     assert_eq!(op.user_data(), user_data);
 
-    let mut buffer = unsafe { op.into_inner().into_inner::<ReadAt<Vec<u8>>>() }
+    let mut buffer = unsafe { op.into_op::<ReadAt<Vec<u8>>>() }
         .into_inner()
         .into_inner();
     unsafe {

--- a/examples/driver.rs
+++ b/examples/driver.rs
@@ -1,12 +1,12 @@
 use arrayvec::ArrayVec;
 use compio::{
     buf::IntoInner,
-    driver::{AsRawFd, Entry, PollDriver},
+    driver::{AsRawFd, Entry, Proactor},
     op::ReadAt,
 };
 
 fn main() {
-    let mut driver = PollDriver::new().unwrap();
+    let mut driver = Proactor::new().unwrap();
     let file = compio::fs::File::open("Cargo.toml").unwrap();
     driver.attach(file.as_raw_fd()).unwrap();
 

--- a/src/driver/iocp/mod.rs
+++ b/src/driver/iocp/mod.rs
@@ -285,7 +285,7 @@ impl AsRawFd for Driver {
 }
 
 #[repr(C)]
-struct Overlapped {
+pub(crate) struct Overlapped {
     #[allow(dead_code)]
     pub base: OVERLAPPED,
     pub user_data: usize,

--- a/src/driver/iocp/mod.rs
+++ b/src/driver/iocp/mod.rs
@@ -114,7 +114,7 @@ pub trait OpCode {
 }
 
 /// Low-level driver of IOCP.
-pub struct Driver {
+pub(crate) struct Driver {
     port: OwnedHandle,
     cancelled: HashSet<usize>,
 }
@@ -122,13 +122,7 @@ pub struct Driver {
 impl Driver {
     const DEFAULT_CAPACITY: usize = 1024;
 
-    /// Create a new IOCP.
-    pub fn new() -> io::Result<Self> {
-        Self::with_entries(Self::DEFAULT_CAPACITY as _)
-    }
-
-    /// The same as [`Driver::new`].
-    pub fn with_entries(_entries: u32) -> io::Result<Self> {
+    pub fn new(_entries: u32) -> io::Result<Self> {
         let port = syscall!(BOOL, CreateIoCompletionPort(INVALID_HANDLE_VALUE, 0, 0, 0))?;
         let port = unsafe { OwnedHandle::from_raw_handle(port as _) };
         Ok(Self {

--- a/src/driver/iocp/op.rs
+++ b/src/driver/iocp/op.rs
@@ -31,7 +31,7 @@ use windows_sys::{
 
 use crate::{
     buf::{AsIoSlices, AsIoSlicesMut, IntoInner, IoBuf, IoBufMut},
-    driver::{iocp::Overlapped, OpCode, RawFd},
+    driver::{OpCode, RawFd},
     op::*,
     syscall,
 };
@@ -469,22 +469,5 @@ impl OpCode for ConnectNamedPipe {
     unsafe fn operate(self: Pin<&mut Self>, optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
         let res = ConnectNamedPipe(self.fd as _, optr);
         win32_result(res, 0)
-    }
-}
-
-#[derive(Debug)]
-pub struct NopPending {}
-
-impl NopPending {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-impl OpCode for NopPending {
-    unsafe fn operate(self: Pin<&mut Self>, optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
-        // This ptr will not be released by the driver.
-        let _ = Box::from_raw(optr.cast::<Overlapped>());
-        Poll::Pending
     }
 }

--- a/src/driver/iour/mod.rs
+++ b/src/driver/iour/mod.rs
@@ -27,7 +27,7 @@ pub trait OpCode {
 }
 
 /// Low-level driver of io-uring.
-pub struct Driver {
+pub(crate) struct Driver {
     inner: IoUring,
     cancel_queue: VecDeque<u64>,
     cancelled: HashSet<u64>,
@@ -36,13 +36,7 @@ pub struct Driver {
 impl Driver {
     const CANCEL: u64 = u64::MAX;
 
-    /// Create a new io-uring driver with 1024 entries.
-    pub fn new() -> io::Result<Self> {
-        Self::with_entries(1024)
-    }
-
-    /// Create a new io-uring driver with specified entries.
-    pub fn with_entries(entries: u32) -> io::Result<Self> {
+    pub fn new(entries: u32) -> io::Result<Self> {
         Ok(Self {
             inner: IoUring::new(entries)?,
             cancel_queue: VecDeque::default(),

--- a/src/driver/mio/mod.rs
+++ b/src/driver/mio/mod.rs
@@ -64,7 +64,7 @@ pub struct WaitArg {
 }
 
 /// Low-level driver of mio.
-pub struct Driver {
+pub(crate) struct Driver {
     events: Events,
     poll: Poll,
     waiting: HashMap<usize, WaitEntry>,
@@ -96,13 +96,7 @@ impl WaitEntry {
 }
 
 impl Driver {
-    /// Create a new mio driver with 1024 entries.
-    pub fn new() -> io::Result<Self> {
-        Self::with_entries(1024)
-    }
-
-    /// Create a new mio driver with the given number of entries.
-    pub fn with_entries(entries: u32) -> io::Result<Self> {
+    pub fn new(entries: u32) -> io::Result<Self> {
         let entries = entries as usize; // for the sake of consistency, use u32 like iour
 
         Ok(Self {

--- a/src/driver/mio/mod.rs
+++ b/src/driver/mio/mod.rs
@@ -5,7 +5,6 @@ use std::{
     io,
     ops::ControlFlow,
     pin::Pin,
-    ptr::NonNull,
     time::Duration,
 };
 
@@ -15,8 +14,9 @@ use mio::{
     unix::SourceFd,
     Events, Interest, Poll, Token,
 };
+use slab::Slab;
 
-use crate::driver::{Entry, Operation, Poller};
+use crate::driver::{Entry, RawOp};
 
 pub(crate) mod op;
 
@@ -73,25 +73,13 @@ pub(crate) struct Driver {
 
 /// Entry waiting for events
 struct WaitEntry {
-    op: NonNull<dyn OpCode>,
     arg: WaitArg,
     user_data: usize,
 }
 
 impl WaitEntry {
-    fn new(mut mio_entry: Operation, arg: WaitArg) -> Self {
-        let user_data = mio_entry.user_data();
-        // Safety: to make the borrow checker happy
-        let op = NonNull::from(unsafe {
-            std::mem::transmute::<_, &'static mut dyn OpCode>(
-                mio_entry.opcode_pin().get_unchecked_mut(),
-            )
-        });
-        Self { op, arg, user_data }
-    }
-
-    fn op_pin(&mut self) -> Pin<&mut dyn OpCode> {
-        unsafe { Pin::new_unchecked(self.op.as_mut()) }
+    fn new(user_data: usize, arg: WaitArg) -> Self {
+        Self { arg, user_data }
     }
 }
 
@@ -109,37 +97,39 @@ impl Driver {
 }
 
 impl Driver {
-    fn submit(&mut self, entry: Operation, arg: WaitArg) -> io::Result<()> {
-        if !self.cancelled.remove(&entry.user_data) {
-            let token = Token(entry.user_data);
+    fn submit(&mut self, user_data: usize, arg: WaitArg) -> io::Result<()> {
+        if !self.cancelled.remove(&user_data) {
+            let token = Token(user_data);
 
             SourceFd(&arg.fd).register(self.poll.registry(), token, arg.interest)?;
 
             // Only insert the entry after it was registered successfully
             self.waiting
-                .insert(entry.user_data, WaitEntry::new(entry, arg));
+                .insert(user_data, WaitEntry::new(user_data, arg));
         }
         Ok(())
     }
 
     /// Register all operations in the squeue to mio.
-    fn submit_squeue<'a>(
+    fn submit_squeue(
         &mut self,
-        ops: &mut impl Iterator<Item = Operation<'a>>,
+        ops: &mut impl Iterator<Item = usize>,
         entries: &mut impl Extend<Entry>,
+        registry: &mut Slab<RawOp>,
     ) -> io::Result<bool> {
         let mut extended = false;
-        for mut entry in ops {
-            match unsafe { entry.opcode_pin() }.pre_submit() {
+        for user_data in ops {
+            let op = registry[user_data].as_pin();
+            match op.pre_submit() {
                 Ok(Decision::Wait(arg)) => {
-                    self.submit(entry, arg)?;
+                    self.submit(user_data, arg)?;
                 }
                 Ok(Decision::Completed(res)) => {
-                    entries.extend(Some(Entry::new(entry.user_data, Ok(res))));
+                    entries.extend(Some(Entry::new(user_data, Ok(res))));
                     extended = true;
                 }
                 Err(err) => {
-                    entries.extend(Some(Entry::new(entry.user_data, Err(err))));
+                    entries.extend(Some(Entry::new(user_data, Err(err))));
                     extended = true;
                 }
             }
@@ -154,6 +144,7 @@ impl Driver {
         &mut self,
         timeout: Option<Duration>,
         entries: &mut impl Extend<Entry>,
+        registry: &mut Slab<RawOp>,
     ) -> io::Result<()> {
         self.poll.poll(&mut self.events, timeout)?;
         for event in &self.events {
@@ -162,7 +153,8 @@ impl Driver {
                 .waiting
                 .get_mut(&token.0)
                 .expect("Unknown token returned by mio"); // XXX: Should this be silently ignored?
-            let res = match entry.op_pin().on_event(event) {
+            let op = registry[entry.user_data].as_pin();
+            let res = match op.on_event(event) {
                 Ok(ControlFlow::Continue(_)) => continue,
                 Ok(ControlFlow::Break(res)) => Ok(res),
                 Err(err) => Err(err),
@@ -176,14 +168,12 @@ impl Driver {
         }
         Ok(())
     }
-}
 
-impl Poller for Driver {
-    fn attach(&mut self, _fd: RawFd) -> io::Result<()> {
+    pub fn attach(&mut self, _fd: RawFd) -> io::Result<()> {
         Ok(())
     }
 
-    fn cancel(&mut self, user_data: usize) {
+    pub fn cancel(&mut self, user_data: usize) {
         if let Some(entry) = self.waiting.remove(&user_data) {
             self.poll
                 .registry()
@@ -194,15 +184,16 @@ impl Poller for Driver {
         }
     }
 
-    unsafe fn poll<'a>(
+    pub unsafe fn poll(
         &mut self,
         timeout: Option<Duration>,
-        ops: &mut impl Iterator<Item = Operation<'a>>,
+        ops: &mut impl Iterator<Item = usize>,
         entries: &mut impl Extend<Entry>,
+        registry: &mut Slab<RawOp>,
     ) -> io::Result<()> {
-        let extended = self.submit_squeue(ops, entries)?;
+        let extended = self.submit_squeue(ops, entries, registry)?;
         if !extended {
-            self.poll_impl(timeout, entries)?;
+            self.poll_impl(timeout, entries, registry)?;
         }
         Ok(())
     }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -162,14 +162,14 @@ impl Proactor {
     pub fn pop<'a>(
         &'a mut self,
         entries: &'a mut impl Iterator<Item = Entry>,
-    ) -> impl Iterator<Item = BufResult<usize, OwnedOperation>> + 'a {
+    ) -> impl Iterator<Item = BufResult<usize, Operation>> + 'a {
         std::iter::from_fn(|| {
             entries.next().map(|entry| {
                 let op = self
                     .ops
                     .try_remove(entry.user_data())
                     .expect("the entry should be valid");
-                let op = OwnedOperation::new(op, entry.user_data());
+                let op = Operation::new(op, entry.user_data());
                 (entry.into_result(), op)
             })
         })
@@ -183,12 +183,12 @@ impl AsRawFd for Proactor {
 }
 
 /// Contains the operation and the user_data.
-pub struct OwnedOperation {
+pub struct Operation {
     op: RawOp,
     user_data: usize,
 }
 
-impl OwnedOperation {
+impl Operation {
     pub(crate) fn new(op: RawOp, user_data: usize) -> Self {
         Self { op, user_data }
     }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -155,7 +155,7 @@ impl PollDriver {
     /// Cancel an operation with the pushed user-defined data.
     ///
     /// The cancellation is not reliable. The underlying operation may continue,
-    /// but just don't return from [`Poller::poll`]. Therefore, although an
+    /// but just don't return from [`PollDriver::poll`]. Therefore, although an
     /// operation is cancelled, you should not reuse its `user_data`.
     ///
     /// It is well-defined to cancel before polling. If the submitted operation
@@ -296,7 +296,7 @@ impl Entry {
         Self { user_data, result }
     }
 
-    /// The user-defined data passed to [`Operation`].
+    /// The user-defined data returned by [`PollDriver::push`].
     pub fn user_data(&self) -> usize {
         self.user_data
     }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -241,7 +241,7 @@ impl OwnedOperation {
     ///
     /// The caller should guarantee that the type is right.
     pub unsafe fn into_op<T: OpCode>(self) -> T {
-        self.op.into_inner()
+        self.into_inner().into_inner()
     }
 
     /// The same user_data when the operation is pushed into the driver.

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -9,9 +9,9 @@ use crate::{
     driver::AsRawFd,
     op::{BufResultExt, ReadAt, Sync, WriteAt},
     task::RUNTIME,
-    Attacher, BufResult,
+    vec_alloc, Attacher, BufResult,
 };
-use crate::{fs::OpenOptions, impl_raw_fd, vec_alloc};
+use crate::{fs::OpenOptions, impl_raw_fd};
 
 /// A reference to an open file on the filesystem.
 ///
@@ -261,11 +261,10 @@ impl File {
         let mut total_written = 0;
         let mut written;
         while total_written < buf_len {
-            (written, buffer) = buf_try!(
-                self.write_at(buffer.slice(total_written..), pos + total_written)
-                    .await
-                    .into_inner()
-            );
+            (written, buffer) = buf_try!(self
+                .write_at(buffer.slice(total_written..), pos + total_written)
+                .await
+                .into_inner());
             total_written += written;
         }
         (Ok(total_written), buffer)

--- a/src/key.rs
+++ b/src/key.rs
@@ -31,14 +31,6 @@ impl<T> Key<T> {
     }
 }
 
-impl Key<()> {
-    /// Create a new dummy `Key` with the given user data
-    pub fn new_dummy(user_data: usize) -> Self {
-        // Safety: `()` is not `OpCode` so this won't be used to poll data from drivers.
-        unsafe { Self::new(user_data) }
-    }
-}
-
 impl<T> std::ops::Deref for Key<T> {
     type Target = usize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ macro_rules! syscall {
 
 /// Helper macro to execute a system call
 #[cfg(unix)]
+#[allow(unused_macros)]
 macro_rules! syscall {
     ($fn: ident ( $($arg: expr),* $(,)* ) ) => {{
         #[allow(unused_unsafe)]
@@ -138,6 +139,7 @@ macro_rules! syscall {
     };
 }
 
+#[allow(unused_imports)]
 pub(crate) use syscall;
 
 #[cfg(not(feature = "allocator_api"))]

--- a/src/named_pipe.rs
+++ b/src/named_pipe.rs
@@ -33,7 +33,7 @@ use crate::{buf::*, op::ConnectNamedPipe, task::RUNTIME, *};
 use crate::{
     driver::{AsRawFd, FromRawFd, RawFd},
     fs::File,
-    impl_raw_fd,
+    impl_raw_fd, syscall,
 };
 
 /// A [Windows named pipe] server.

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,7 +1,7 @@
 //! The async operations.
 //! Types in this mod represents the low-level operations passed to kernel.
 //! The operation itself doesn't perform anything.
-//! You need to pass them to [`crate::driver::Driver`], and poll the driver.
+//! You need to pass them to [`crate::driver::PollDriver`], and poll the driver.
 
 use socket2::SockAddr;
 

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,7 +1,7 @@
 //! The async operations.
 //! Types in this mod represents the low-level operations passed to kernel.
 //! The operation itself doesn't perform anything.
-//! You need to pass them to [`crate::driver::PollDriver`], and poll the driver.
+//! You need to pass them to [`crate::driver::Proactor`], and poll the driver.
 
 use socket2::SockAddr;
 

--- a/src/task/op.rs
+++ b/src/task/op.rs
@@ -1,41 +1,18 @@
 use std::{
+    collections::HashMap,
     future::Future,
     io,
     marker::PhantomData,
-    mem::ManuallyDrop,
     pin::Pin,
-    ptr::NonNull,
     task::{Context, Poll, Waker},
 };
 
-use slab::Slab;
+use crate::{
+    driver::{OpCode, RawOp},
+    key::Key,
+};
 
-use crate::{driver::OpCode, key::Key};
-
-pub struct RawOp(NonNull<dyn OpCode>);
-
-impl RawOp {
-    pub fn new(op: impl OpCode + 'static) -> Self {
-        let op = Box::new(op);
-        Self(unsafe { NonNull::new_unchecked(Box::into_raw(op as Box<dyn OpCode>)) })
-    }
-
-    pub fn as_dyn_mut(&mut self) -> &mut dyn OpCode {
-        unsafe { self.0.as_mut() }
-    }
-
-    pub unsafe fn into_inner<T: OpCode>(self) -> T {
-        let this = ManuallyDrop::new(self);
-        *Box::from_raw(this.0.cast().as_ptr())
-    }
-}
-
-impl Drop for RawOp {
-    fn drop(&mut self) {
-        drop(unsafe { Box::from_raw(self.0.as_ptr()) })
-    }
-}
-
+#[derive(Default)]
 pub struct RegisteredOp {
     pub op: Option<RawOp>,
     pub waker: Option<Waker>,
@@ -43,70 +20,41 @@ pub struct RegisteredOp {
     pub cancelled: bool,
 }
 
-impl RegisteredOp {
-    fn new(op: Option<RawOp>) -> Self {
-        Self {
-            op,
-            waker: None,
-            result: None,
-            cancelled: false,
-        }
-    }
-}
-
 #[derive(Default)]
 pub(crate) struct OpRuntime {
-    ops: Slab<RegisteredOp>,
+    ops: HashMap<usize, RegisteredOp>,
 }
 
 impl OpRuntime {
-    pub fn insert<T: OpCode + 'static>(&mut self, op: T) -> Key<T> {
-        let user_data = self.ops.insert(RegisteredOp::new(Some(RawOp::new(op))));
-        // Safety: `user_data` corresponds to `op` inserted which has type `T`.
-        unsafe { Key::new(user_data) }
-    }
-
-    pub fn insert_dummy(&mut self) -> Key<()> {
-        Key::new_dummy(self.ops.insert(RegisteredOp::new(None)))
-    }
-
-    pub fn get_raw_op(&mut self, key: usize) -> &mut RawOp {
-        self.ops.get_mut(key).unwrap().op.as_mut().unwrap()
-    }
-
     pub fn update_waker<T>(&mut self, key: Key<T>, waker: Waker) {
-        if let Some(op) = self.ops.get_mut(*key) {
-            op.waker = Some(waker);
-        }
+        self.ops.entry(*key).or_default().waker = Some(waker);
     }
 
-    pub fn update_result<T>(&mut self, key: Key<T>, result: io::Result<usize>) {
-        if let Some(op) = self.ops.get_mut(*key) {
-            if let Some(waker) = op.waker.take() {
-                waker.wake();
-            }
-            op.result = Some(result);
-            if op.cancelled {
-                self.remove(key);
-            }
+    pub fn update_result<T>(&mut self, key: Key<T>, raw_op: RawOp, result: io::Result<usize>) {
+        let op = self.ops.entry(*key).or_default();
+        if let Some(waker) = op.waker.take() {
+            waker.wake();
+        }
+        op.op = Some(raw_op);
+        op.result = Some(result);
+        if op.cancelled {
+            self.remove(key);
         }
     }
 
     pub fn has_result<T>(&mut self, key: Key<T>) -> bool {
         self.ops
-            .get_mut(*key)
+            .get_mut(&key)
             .map(|op| op.result.is_some())
             .unwrap_or_default()
     }
 
     pub fn cancel<T>(&mut self, key: Key<T>) {
-        if let Some(ops) = self.ops.get_mut(*key) {
-            ops.cancelled = true;
-        }
+        self.ops.entry(*key).or_default().cancelled = true;
     }
 
     pub fn remove<T>(&mut self, key: Key<T>) -> RegisteredOp {
-        self.ops.remove(*key)
+        self.ops.remove(&key).unwrap()
     }
 }
 
@@ -132,18 +80,6 @@ impl<T: OpCode> Future for OpFuture<T> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let res = crate::task::RUNTIME.with(|runtime| runtime.poll_task(cx, self.user_data));
-        if res.is_ready() {
-            self.get_mut().completed = true;
-        }
-        res
-    }
-}
-
-impl Future for OpFuture<()> {
-    type Output = io::Result<usize>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let res = crate::task::RUNTIME.with(|runtime| runtime.poll_dummy(cx, self.user_data));
         if res.is_ready() {
             self.get_mut().completed = true;
         }

--- a/src/task/op.rs
+++ b/src/task/op.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 #[derive(Default)]
-pub struct RegisteredOp {
+pub(crate) struct RegisteredOp {
     pub op: Option<RawOp>,
     pub waker: Option<Waker>,
     pub result: Option<io::Result<usize>>,

--- a/src/task/runtime.rs
+++ b/src/task/runtime.rs
@@ -3,7 +3,6 @@ use std::{
     collections::VecDeque,
     future::Future,
     io,
-    ptr::NonNull,
     task::{Context, Poll},
 };
 
@@ -13,15 +12,14 @@ use smallvec::SmallVec;
 #[cfg(feature = "time")]
 use crate::task::time::{TimerFuture, TimerRuntime};
 use crate::{
-    driver::{AsRawFd, Driver, Entry, OpCode, Poller, RawFd},
+    driver::{AsRawFd, Entry, OpCode, PollDriver, RawFd},
     task::op::{OpFuture, OpRuntime},
     Key,
 };
 
 pub(crate) struct Runtime {
-    driver: RefCell<Driver>,
+    driver: RefCell<PollDriver>,
     runnables: RefCell<VecDeque<Runnable>>,
-    squeue: RefCell<VecDeque<usize>>,
     op_runtime: RefCell<OpRuntime>,
     #[cfg(feature = "time")]
     timer_runtime: RefCell<TimerRuntime>,
@@ -30,9 +28,8 @@ pub(crate) struct Runtime {
 impl Runtime {
     pub fn new() -> io::Result<Self> {
         Ok(Self {
-            driver: RefCell::new(Driver::new()?),
+            driver: RefCell::new(PollDriver::new()?),
             runnables: RefCell::default(),
-            squeue: RefCell::default(),
             op_runtime: RefCell::default(),
             #[cfg(feature = "time")]
             timer_runtime: RefCell::new(TimerRuntime::new()),
@@ -79,19 +76,17 @@ impl Runtime {
         self.driver.borrow_mut().attach(fd)
     }
 
+    pub fn submit_raw<T: OpCode + 'static>(&self, op: T) -> Key<T> {
+        let user_data = self.driver.borrow_mut().push(op);
+        unsafe { Key::<T>::new(user_data) }
+    }
+
     pub fn submit<T: OpCode + 'static>(
         &self,
         op: T,
     ) -> impl Future<Output = (io::Result<usize>, T)> {
-        let mut op_runtime = self.op_runtime.borrow_mut();
-        let user_data = op_runtime.insert(op);
-        self.squeue.borrow_mut().push_back(*user_data);
+        let user_data = self.submit_raw(op);
         self.spawn(OpFuture::new(user_data))
-    }
-
-    #[allow(dead_code)]
-    pub fn submit_dummy(&self) -> Key<()> {
-        self.op_runtime.borrow_mut().insert_dummy()
     }
 
     #[cfg(feature = "time")]
@@ -135,18 +130,6 @@ impl Runtime {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn poll_dummy(&self, cx: &mut Context, user_data: Key<()>) -> Poll<io::Result<usize>> {
-        let mut op_runtime = self.op_runtime.borrow_mut();
-        if op_runtime.has_result(user_data) {
-            let op = op_runtime.remove(user_data);
-            Poll::Ready(op.result.unwrap())
-        } else {
-            op_runtime.update_waker(user_data, cx.waker().clone());
-            Poll::Pending
-        }
-    }
-
     #[cfg(feature = "time")]
     pub fn poll_timer(&self, cx: &mut Context, key: usize) -> Poll<()> {
         let mut timer_runtime = self.timer_runtime.borrow_mut();
@@ -164,25 +147,16 @@ impl Runtime {
         #[cfg(feature = "time")]
         let timeout = self.timer_runtime.borrow().min_timeout();
 
-        let mut squeue = self.squeue.borrow_mut();
-        let mut ops = std::iter::from_fn(|| {
-            squeue.pop_front().map(|user_data| {
-                let mut op = NonNull::from(self.op_runtime.borrow_mut().get_raw_op(user_data));
-                // Safety: op won't outlive.
-                (unsafe { op.as_mut() }.as_dyn_mut(), user_data).into()
-            })
-        });
         let mut entries = SmallVec::<[Entry; 1024]>::new();
-        match unsafe {
-            self.driver
-                .borrow_mut()
-                .poll(timeout, &mut ops, &mut entries)
-        } {
+        let mut driver = self.driver.borrow_mut();
+        match driver.poll(timeout, &mut entries) {
             Ok(_) => {
-                for entry in entries {
-                    self.op_runtime
-                        .borrow_mut()
-                        .update_result(Key::new_dummy(entry.user_data()), entry.into_result());
+                for (res, op) in driver.pop(&mut entries.into_iter()) {
+                    self.op_runtime.borrow_mut().update_result(
+                        Key::new_dummy(op.user_data()),
+                        op.into_inner(),
+                        res,
+                    );
                 }
             }
             Err(e) => match e.kind() {

--- a/src/task/runtime.rs
+++ b/src/task/runtime.rs
@@ -12,13 +12,13 @@ use smallvec::SmallVec;
 #[cfg(feature = "time")]
 use crate::task::time::{TimerFuture, TimerRuntime};
 use crate::{
-    driver::{AsRawFd, Entry, OpCode, PollDriver, RawFd},
+    driver::{AsRawFd, Entry, OpCode, Proactor, RawFd},
     task::op::{OpFuture, OpRuntime},
     Key,
 };
 
 pub(crate) struct Runtime {
-    driver: RefCell<PollDriver>,
+    driver: RefCell<Proactor>,
     runnables: RefCell<VecDeque<Runnable>>,
     op_runtime: RefCell<OpRuntime>,
     #[cfg(feature = "time")]
@@ -28,7 +28,7 @@ pub(crate) struct Runtime {
 impl Runtime {
     pub fn new() -> io::Result<Self> {
         Ok(Self {
-            driver: RefCell::new(PollDriver::new()?),
+            driver: RefCell::new(Proactor::new()?),
             runnables: RefCell::default(),
             op_runtime: RefCell::default(),
             #[cfg(feature = "time")]

--- a/tests/driver.rs
+++ b/tests/driver.rs
@@ -2,30 +2,24 @@ use std::{io, time::Duration};
 
 use arrayvec::ArrayVec;
 use compio::{
-    driver::{AsRawFd, Driver, Entry, Poller},
+    driver::{AsRawFd, Entry, PollDriver},
     fs::File,
     op::ReadAt,
 };
 
 #[test]
 fn cancel_before_poll() {
-    let mut driver = Driver::new().unwrap();
+    let mut driver = PollDriver::new().unwrap();
 
     let file = File::open("Cargo.toml").unwrap();
     driver.attach(file.as_raw_fd()).unwrap();
 
     driver.cancel(0);
 
-    let mut op = ReadAt::new(file.as_raw_fd(), 0, Vec::with_capacity(8));
-    let ops = [(&mut op, 0).into()];
-    let mut entries = ArrayVec::<Entry, 1>::new();
+    let op = ReadAt::new(file.as_raw_fd(), 0, Vec::with_capacity(8));
+    driver.push(op);
 
-    let res = unsafe {
-        driver.poll(
-            Some(Duration::from_secs(1)),
-            &mut ops.into_iter(),
-            &mut entries,
-        )
-    };
+    let mut entries = ArrayVec::<Entry, 1>::new();
+    let res = driver.poll(Some(Duration::from_secs(1)), &mut entries);
     assert!(res.is_ok() || res.unwrap_err().kind() == io::ErrorKind::TimedOut);
 }

--- a/tests/driver.rs
+++ b/tests/driver.rs
@@ -2,14 +2,14 @@ use std::{io, time::Duration};
 
 use arrayvec::ArrayVec;
 use compio::{
-    driver::{AsRawFd, Entry, PollDriver},
+    driver::{AsRawFd, Entry, Proactor},
     fs::File,
     op::ReadAt,
 };
 
 #[test]
 fn cancel_before_poll() {
-    let mut driver = PollDriver::new().unwrap();
+    let mut driver = Proactor::new().unwrap();
 
     let file = File::open("Cargo.toml").unwrap();
     driver.attach(file.as_raw_fd()).unwrap();

--- a/tests/event.rs
+++ b/tests/event.rs
@@ -5,8 +5,8 @@ fn event_handle() {
     compio::task::block_on(async {
         let event = Event::new().unwrap();
         let handle = event.handle().unwrap();
-        std::thread::scope(|scope| {
-            scope.spawn(|| handle.notify().unwrap());
+        std::thread::spawn(move || {
+            handle.notify().unwrap();
         });
         event.wait().await.unwrap();
     });


### PR DESCRIPTION
Introduced a new safe wrapper called `PollDriver`.

Maybe need to name it `Driver`, and change the original `Driver` type to `NativeDriver`.