### PR TITLE
Make polling available on Linux.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,8 @@ windows-sys = { version = "0.48", features = ["Win32_Security_Authorization"] }
 
 # Linux specific dependencies
 [target.'cfg(target_os = "linux")'.dependencies]
-io-uring = "0.6"
+io-uring = { version = "0.6", optional = true }
+polling = { version = "3", optional = true }
 libc = "0.2"
 
 # Other platform dependencies
@@ -79,7 +80,7 @@ polling = "3"
 libc = "0.2"
 
 [features]
-default = ["runtime"]
+default = ["runtime", "io-uring"]
 runtime = ["dep:async-task", "dep:futures-util", "dep:smallvec"]
 event = ["runtime", "arrayvec"]
 signal = ["event"]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
       - script: |
           rustup toolchain install nightly
           rustup +nightly target install $(target)
-          cargo +nightly test --features=all,nightly --no-default-features --target $(target) -Z doctest-xcompile
+          cargo +nightly test --features=all,nightly --target $(target) -Z doctest-xcompile
         displayName: TestNightly
       - script: |
           cargo test --features all --target $(target)
@@ -39,11 +39,19 @@ jobs:
     steps:
       - script: |
           rustup toolchain install nightly
-          cargo +nightly test --features all,nightly --no-default-features
+          cargo +nightly test --features all,nightly
         displayName: TestNightly
       - script: |
           cargo test --features all
         displayName: TestStable
+
+      - script: |
+          rustup toolchain install nightly
+          cargo +nightly test --features all,polling,nightly --no-default-features
+        displayName: TestNightly-polling
+      - script: |
+          cargo test --features all,polling --no-default-features
+        displayName: TestStable-polling
 
   - job: Test_Mac
     strategy:
@@ -58,7 +66,7 @@ jobs:
     steps:
       - script: |
           rustup toolchain install nightly
-          cargo +nightly test --features all,nightly --no-default-features
+          cargo +nightly test --features all,nightly
         displayName: TestNightly
       - script: |
           cargo test --features all

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,11 +1,19 @@
 //! The platform-specified driver.
 //! Some types differ by compilation target.
 
+#[cfg(all(
+    target_os = "linux",
+    not(feature = "io-uring"),
+    not(feature = "polling")
+))]
+compile_error!("You must choose one of these features: [\"io-uring\", \"polling\"]");
+
 use std::{collections::VecDeque, io, time::Duration};
 
 use slab::Slab;
 
 use crate::BufResult;
+
 #[cfg(unix)]
 mod unix;
 
@@ -13,10 +21,10 @@ cfg_if::cfg_if! {
     if #[cfg(target_os = "windows")] {
         mod iocp;
         pub use iocp::*;
-    } else if #[cfg(target_os = "linux")] {
+    } else if #[cfg(all(target_os = "linux", feature = "io-uring"))] {
         mod iour;
         pub use iour::*;
-    } else if #[cfg(unix)]{
+    } else if #[cfg(unix)] {
         mod poll;
         pub use poll::*;
     }

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -59,7 +59,7 @@ impl Socket {
         // non blocking socket when there is no connections in listen queue
         //
         // https://patchwork.kernel.org/project/linux-block/patch/f999615b-205c-49b7-b272-c4e42e45e09d@kernel.dk/#22949861
-        #[cfg(all(unix, not(feature = "io-uring")))]
+        #[cfg(all(unix, not(all(target_os = "linux", feature = "io-uring"))))]
         socket.set_nonblocking(true)?;
         Ok(Self::from_socket2(socket))
     }

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -59,7 +59,7 @@ impl Socket {
         // non blocking socket when there is no connections in listen queue
         //
         // https://patchwork.kernel.org/project/linux-block/patch/f999615b-205c-49b7-b272-c4e42e45e09d@kernel.dk/#22949861
-        #[cfg(all(unix, not(target_os = "linux")))]
+        #[cfg(all(unix, not(feature = "io-uring")))]
         socket.set_nonblocking(true)?;
         Ok(Self::from_socket2(socket))
     }


### PR DESCRIPTION
Linux system which doesn't enable io-uring can use epoll instead. However, epoll doesn't support disk files, which means the file IO is synconized.